### PR TITLE
Ported to Windows with MSYS2

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -17,8 +17,12 @@ module Rdkafka
       end
     end
 
-    ffi_lib File.join(__dir__, "../../ext/librdkafka.#{lib_extension}")
-
+    if Gem.win_platform?
+      ffi_lib 'librdkafka'
+    else
+      ffi_lib File.join(__dir__, "../../ext/librdkafka.#{lib_extension}")
+    end
+      
     RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS = -175
     RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS = -174
     RD_KAFKA_RESP_ERR__NOENT = -156

--- a/rdkafka.gemspec
+++ b/rdkafka.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version = Rdkafka::VERSION
   gem.required_ruby_version = '>= 2.6'
-  gem.extensions = %w(ext/Rakefile)
+  gem.extensions = %w(ext/Rakefile) unless Gem.win_platform?
 
   gem.add_dependency 'ffi', '~> 1.15'
   gem.add_dependency 'mini_portile2', '~> 2.6'
@@ -29,4 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-rspec'
+
+  gem.metadata['msys2_mingw_dependencies'] = 'librdkafka' if Gem.win_platform?
 end

--- a/spec/rdkafka/admin_spec.rb
+++ b/spec/rdkafka/admin_spec.rb
@@ -33,7 +33,7 @@ describe Rdkafka::Admin do
           }.to raise_exception { |ex|
             expect(ex).to be_a(Rdkafka::RdkafkaError)
             expect(ex.message).to match(/Broker: Invalid topic \(topic_exception\)/)
-            expect(ex.broker_message).to match(/Topic name.*is illegal, it contains a character other than ASCII alphanumerics/)
+            expect(ex.broker_message).to match(/Topic name.*is illegal, it contains a character other than ASCII alphanumerics|Topic name is invalid: '#{Regexp.quote(topic_name)}' contains one or more characters other than ASCII alphanumerics, '.', '_' and '-'/)
           }
         end
       end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -455,7 +455,7 @@ describe Rdkafka::Producer do
     end
   end
 
-  it "should produce a message in a forked process", skip: defined?(JRUBY_VERSION) && "Kernel#fork is not available" do
+  it "should produce a message in a forked process", skip: !Process.respond_to?(:fork) && "Kernel#fork is not available" do
     # Fork, produce a message, send the report over a pipe and
     # wait for and check the message in the main process.
     reader, writer = IO.pipe


### PR DESCRIPTION
Windows with MSYS2 has _librdkafka_ available through `pacman` MSYS2 package management. This PR modifies **rdkafka-ruby** to detect it's running on windows with `Gem.win_platform?` and if that's the case, relies on [Rubyinstaller2 MSYS2 Library Dependency](https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency) to check and install the _librdkafka_ package.

The platform check in the forking spec is replaced as recommended in [Kernel.fork](https://ruby-doc.org/3.1.3/Kernel.html#method-i-fork) Ruby official documentation.

When _librdkafka_ is installed by `pacman` in the MSYS2 system, `ffli_lib` finds it automatically.