### PR TITLE
set stacktrace for asyn errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Enhancement] Introduce producer partitions count metadata cache (mensfeld)
 * [Enhancement] Increase metadata timeout request from `250 ms` to `2000 ms` default to allow for remote cluster operations via `rdkafka-ruby` (mensfeld)
 * [Enhancement] Introduce `#name` for producers and consumers (mensfeld)
+* [Enhancement] Include backtrace in non-raised binded errors (mensfeld)
 * [Fix] `#flush` does not handle the timeouts errors by making it return `true` if all flushed or `false` if failed. We do **not** raise an exception here to keep it backwards compatible (mensfeld)
 * [Change] Remove support for Ruby 2.6 due to it being EOL and WeakMap incompatibilities (mensfeld)
 * [Change] Update Kafka Docker with Confluent KRaft (mensfeld)

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -158,6 +158,7 @@ module Rdkafka
     ) do |_client_prr, err_code, reason, _opaque|
       if Rdkafka::Config.error_callback
         error = Rdkafka::RdkafkaError.new(err_code, broker_message: reason)
+        error.set_backtrace(caller)
         Rdkafka::Config.error_callback.call(error)
       end
     end


### PR DESCRIPTION
There is no stacktrace at all for those errors but other errors have it. This fixes that.