### PR TITLE
Update librdkafka location reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [Fix] `#flush` does not handle the timeouts errors by making it return `true` if all flushed or `false` if failed. We do **not** raise an exception here to keep it backwards compatible (mensfeld)
 * [Change] Remove support for Ruby 2.6 due to it being EOL and WeakMap incompatibilities (mensfeld)
 * [Change] Update Kafka Docker with Confluent KRaft (mensfeld)
+* [Change] Update librdkafka repo reference from edenhill to confluentinc (mensfeld)
 
 ## 0.13.0 (2023-07-24)
 * Support cooperative sticky partition assignment in the rebalance callback (methodmissing)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ---
 
 The `rdkafka` gem is a modern Kafka client library for Ruby based on
-[librdkafka](https://github.com/edenhill/librdkafka/).
+[librdkafka](https://github.com/confluentinc/librdkafka/).
 It wraps the production-ready C client using the [ffi](https://github.com/ffi/ffi)
 gem and targets Kafka 1.0+ and Ruby versions under security or
 active maintenance. We remove a Ruby version from our CI builds when they 

--- a/ext/README.md
+++ b/ext/README.md
@@ -5,7 +5,7 @@ this gem is installed.
 
 To update the `librdkafka` version follow the following steps:
 
-* Go to https://github.com/edenhill/librdkafka/releases to get the new
+* Go to https://github.com/confluentinc/librdkafka/releases to get the new
   version number and asset checksum for `tar.gz`.
 * Change the version in `lib/rdkafka/version.rb`
 * Change the `sha256` in `lib/rdkafka/version.rb`

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -17,7 +17,7 @@ task :default => :clean do
   end
 
   recipe.files << {
-    :url => "https://codeload.github.com/edenhill/librdkafka/tar.gz/v#{Rdkafka::LIBRDKAFKA_VERSION}",
+    :url => "https://codeload.github.com/confluentinc/librdkafka/tar.gz/v#{Rdkafka::LIBRDKAFKA_VERSION}",
     :sha256 => Rdkafka::LIBRDKAFKA_SOURCE_SHA256
   }
   recipe.configure_options = ["--host=#{recipe.host}"]

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -5,7 +5,7 @@ require "logger"
 module Rdkafka
   # Configuration for a Kafka consumer or producer. You can create an instance and use
   # the consumer and producer methods to create a client. Documentation of the available
-  # configuration options is available on https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
+  # configuration options is available on https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md.
   class Config
     # @private
     @@logger = Logger.new(STDOUT)
@@ -53,7 +53,7 @@ module Rdkafka
 
     # Set a callback that will be called every time the underlying client emits statistics.
     # You can configure if and how often this happens using `statistics.interval.ms`.
-    # The callback is called with a hash that's documented here: https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
+    # The callback is called with a hash that's documented here: https://github.com/confluentinc//librdkafka/blob/master/STATISTICS.md
     #
     # @param callback [Proc, #call] The callback
     #

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -53,7 +53,7 @@ module Rdkafka
 
     # Set a callback that will be called every time the underlying client emits statistics.
     # You can configure if and how often this happens using `statistics.interval.ms`.
-    # The callback is called with a hash that's documented here: https://github.com/confluentinc//librdkafka/blob/master/STATISTICS.md
+    # The callback is called with a hash that's documented here: https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
     #
     # @param callback [Proc, #call] The callback
     #


### PR DESCRIPTION
This PR changes repo org reference from edenhill to confluentinc because of the location transition.