### PR TITLE
allow stats cb reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
 ## 0.14.0 (Unreleased)
+- [Enhancement] Allow for setting `statistics_callback` as nil to reset predefined settings configured by a different gem (mensfeld)
 * [Enhancement] Get consumer position (thijsc & mensfeld)
 * [Enhancement] Provide `#purge` to remove any outstanding requests from the producer (mensfeld)
 * [Enhancement] Update `librdkafka` to `2.2.0` (mensfeld)

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -57,7 +57,7 @@ module Rdkafka
     #
     # @return [nil]
     def self.statistics_callback=(callback)
-      raise TypeError.new("Callback has to be callable") unless callback.respond_to?(:call)
+      raise TypeError.new("Callback has to be callable") unless callback.respond_to?(:call) || callback == nil
       @@statistics_callback = callback
     end
 


### PR DESCRIPTION
Small PR allowing to reset the statistics callback state to the default nil.

part of https://github.com/karafka/rdkafka-ruby/issues/303