### PR TITLE
improve report building

### DIFF
--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -24,7 +24,9 @@ module Rdkafka
         DeliveryReport.new(
           self[:partition],
           self[:offset],
-          self[:topic_name].read_string,
+          # For part of errors, we will not get a topic name reference and in cases like this
+          # we should not return it
+          self[:topic_name].null? ? nil : self[:topic_name].read_string,
           self[:response] != 0 ? RdkafkaError.new(self[:response]) : nil,
           label
         )

--- a/lib/rdkafka/producer/delivery_report.rb
+++ b/lib/rdkafka/producer/delivery_report.rb
@@ -12,8 +12,10 @@ module Rdkafka
       # @return [Integer]
       attr_reader :offset
 
-      # The name of the topic this message was produced to.
-      # @return [String]
+      # The name of the topic this message was produced to or nil in case of reports with errors
+      # where topic was not reached.
+      #
+      # @return [String, nil]
       attr_reader :topic_name
 
       # Error in case happen during produce.


### PR DESCRIPTION
This is a backport from karafka-rdkafka that handles a case where a failed report (one with error) would contain error that did not have a topic because the message did not reach it. I do not recall an exact case where it was happening but I do know it did.