### PR TITLE
run ci only on most recent 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - '3.0'
           - '3.0.0'
           - '2.7'
-          - '2.7.0'
         include:
           - ruby: '3.3'
             coverage: 'true'


### PR DESCRIPTION
This PR will make CI run on 2.7.8 but not 2.7.0. 

close https://github.com/karafka/karafka/issues/1833