### PR TITLE
v0.15.1 release + desc change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Rdkafka Changelog
 
-## 0.15.1 (Unreleased)
+## 0.15.1 (2024-01-30)
 - [Enhancement] Provide support for Nix OS (alexandriainfantino)
 - [Enhancement] Replace `rd_kafka_offset_store` with `rd_kafka_offsets_store` (mensfeld)
 - [Enhancement] Alias `topic_name` as `topic` in the delivery report (mensfeld)

--- a/rdkafka.gemspec
+++ b/rdkafka.gemspec
@@ -3,10 +3,10 @@
 require File.expand_path('lib/rdkafka/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors = ['Thijs Cadier']
+  gem.authors = ['Thijs Cadier', 'Maciej Mensfeld']
   gem.email = ["contact@karafka.io"]
   gem.description = "Modern Kafka client library for Ruby based on librdkafka"
-  gem.summary = "The rdkafka gem is a modern Kafka client library for Ruby based on librdkafka. It wraps the production-ready C client using the ffi gem and targets Kafka 1.0+ and Ruby 2.4+."
+  gem.summary = "The rdkafka gem is a modern Kafka client library for Ruby based on librdkafka. It wraps the production-ready C client using the ffi gem and targets Kafka 1.0+ and Ruby 2.7+."
   gem.license = 'MIT'
 
   gem.files = `git ls-files`.split($\)


### PR DESCRIPTION
I noticed, that the description in the gem states Ruby 2.4+ but atm it is Ruby 2.7+