### PR TITLE
fix unlock race condition

### DIFF
--- a/lib/rdkafka/abstract_handle.rb
+++ b/lib/rdkafka/abstract_handle.rb
@@ -94,7 +94,10 @@ module Rdkafka
 
     # Unlock the resources
     def unlock
-      @resource.broadcast
+      @mutex.synchronize do
+        self[:pending] = false
+        @resource.broadcast
+      end
     end
 
     # @return [String] the name of the operation (e.g. "delivery")

--- a/lib/rdkafka/admin/create_topic_report.rb
+++ b/lib/rdkafka/admin/create_topic_report.rb
@@ -16,7 +16,7 @@ module Rdkafka
           @error_string = error_string.read_string
         end
         if result_name != FFI::Pointer::NULL
-          @result_name = @result_name = result_name.read_string
+          @result_name = result_name.read_string
         end
       end
     end

--- a/lib/rdkafka/admin/delete_groups_report.rb
+++ b/lib/rdkafka/admin/delete_groups_report.rb
@@ -16,7 +16,7 @@ module Rdkafka
           @error_string = error_string.read_string
         end
         if result_name != FFI::Pointer::NULL
-          @result_name = @result_name = result_name.read_string
+          @result_name = result_name.read_string
         end
       end
     end

--- a/lib/rdkafka/admin/delete_topic_report.rb
+++ b/lib/rdkafka/admin/delete_topic_report.rb
@@ -16,7 +16,7 @@ module Rdkafka
           @error_string = error_string.read_string
         end
         if result_name != FFI::Pointer::NULL
-          @result_name = @result_name = result_name.read_string
+          @result_name = result_name.read_string
         end
       end
     end

--- a/lib/rdkafka/callbacks.rb
+++ b/lib/rdkafka/callbacks.rb
@@ -156,7 +156,6 @@ module Rdkafka
           create_topic_handle[:response] = create_topic_results[0].result_error
           create_topic_handle[:error_string] = create_topic_results[0].error_string
           create_topic_handle[:result_name] = create_topic_results[0].result_name
-          create_topic_handle[:pending] = false
 
           create_topic_handle.unlock
         end
@@ -175,7 +174,6 @@ module Rdkafka
           delete_group_handle[:response] = delete_group_results[0].result_error
           delete_group_handle[:error_string] = delete_group_results[0].error_string
           delete_group_handle[:result_name] = delete_group_results[0].result_name
-          delete_group_handle[:pending] = false
 
           delete_group_handle.unlock
         end
@@ -194,7 +192,6 @@ module Rdkafka
           delete_topic_handle[:response] = delete_topic_results[0].result_error
           delete_topic_handle[:error_string] = delete_topic_results[0].error_string
           delete_topic_handle[:result_name] = delete_topic_results[0].result_name
-          delete_topic_handle[:pending] = false
 
           delete_topic_handle.unlock
         end
@@ -213,7 +210,6 @@ module Rdkafka
           create_partitions_handle[:response] = create_partitions_results[0].result_error
           create_partitions_handle[:error_string] = create_partitions_results[0].error_string
           create_partitions_handle[:result_name] = create_partitions_results[0].result_name
-          create_partitions_handle[:pending] = false
 
           create_partitions_handle.unlock
         end
@@ -231,7 +227,6 @@ module Rdkafka
         if create_acl_handle = Rdkafka::Admin::CreateAclHandle.remove(create_acl_handle_ptr.address)
           create_acl_handle[:response] = create_acl_results[0].result_error
           create_acl_handle[:response_string] = create_acl_results[0].error_string
-          create_acl_handle[:pending] = false
 
           create_acl_handle.unlock
         end
@@ -249,7 +244,6 @@ module Rdkafka
         if delete_acl_handle = Rdkafka::Admin::DeleteAclHandle.remove(delete_acl_handle_ptr.address)
           delete_acl_handle[:response] = delete_acl_results[0].result_error
           delete_acl_handle[:response_string] = delete_acl_results[0].error_string
-          delete_acl_handle[:pending] = false
 
           if delete_acl_results[0].result_error == 0
             delete_acl_handle[:matching_acls] = delete_acl_results[0].matching_acls
@@ -267,7 +261,6 @@ module Rdkafka
         if describe_acl_handle = Rdkafka::Admin::DescribeAclHandle.remove(describe_acl_handle_ptr.address)
           describe_acl_handle[:response] = describe_acl.result_error
           describe_acl_handle[:response_string] = describe_acl.error_string
-          describe_acl_handle[:pending] = false
 
           if describe_acl.result_error == 0
             describe_acl_handle[:acls]       = describe_acl.matching_acls
@@ -299,7 +292,6 @@ module Rdkafka
           delivery_handle[:partition] = message[:partition]
           delivery_handle[:offset] = message[:offset]
           delivery_handle[:topic_name] = FFI::MemoryPointer.from_string(topic_name)
-          delivery_handle[:pending] = false
 
           # Call delivery callback on opaque
           if opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]


### PR DESCRIPTION
This PR ensures that we change the handler status inside a mutex when we unlock. Otherwise there could be an intermediate state where a critical section would not catch the unlock