### PR TITLE
Allow for disabling regex ext during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.2 (Unreleased)
 - **[Feature]** Oauthbearer token refresh callback (bruce-szalwinski-he)
 - [Enhancement] Replace time poll based wait engine with an event based to improve response times on blocking operations and wait (nijikon + mensfeld)
+- [Enhancement] Allow for usage of the second regex engine of librdkafka by setting `RDKAFKA_DISABLE_REGEX_EXT` during build (mensfeld)
 - [Change] The `wait_timeout` argument in `AbstractHandle.wait` method is deprecated and will be removed in future versions without replacement. We don't rely on it's value anymore (nijikon)
 - [Fix] Background logger stops working after forking causing memory leaks (mensfeld)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Rdkafka Changelog
 
 ## 0.15.2 (Unreleased)
-- [Change] The `wait_timeout` argument in `AbstractHandle.wait` method is deprecated and will be removed in future versions without replacement. We don't rely on it's value anymore (nijikon)
+- **[Feature]** Oauthbearer token refresh callback (bruce-szalwinski-he)
 - [Enhancement] Replace time poll based wait engine with an event based to improve response times on blocking operations and wait (nijikon + mensfeld)
+- [Change] The `wait_timeout` argument in `AbstractHandle.wait` method is deprecated and will be removed in future versions without replacement. We don't rely on it's value anymore (nijikon)
 - [Fix] Background logger stops working after forking causing memory leaks (mensfeld)
 
 ## 0.15.1 (2024-01-30)

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -27,6 +27,14 @@ task :default => :clean do
       :sha256 => Rdkafka::LIBRDKAFKA_SOURCE_SHA256
     }
     recipe.configure_options = ["--host=#{recipe.host}"]
+
+    # Disable using libc regex engine in favor of the embedded one
+    # The default regex engine of librdkafka does not always work exactly as most of the users
+    # would expect, hence this flag allows for changing it to the other one
+    if ENV['RDKAFKA_DISABLE_REGEX_EXT']
+      recipe.configure_options << '--disable-regex-ext'
+    end
+
     recipe.cook
     # Move dynamic library we're interested in
     if recipe.host.include?('darwin')

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -31,7 +31,7 @@ task :default => :clean do
     # Disable using libc regex engine in favor of the embedded one
     # The default regex engine of librdkafka does not always work exactly as most of the users
     # would expect, hence this flag allows for changing it to the other one
-    if ENV['RDKAFKA_DISABLE_REGEX_EXT']
+    if ENV.key?('RDKAFKA_DISABLE_REGEX_EXT')
       recipe.configure_options << '--disable-regex-ext'
     end
 


### PR DESCRIPTION
Currently librdkafka by default uses libc regex engine. It is somehow weird not supporting things like `\d\d` and other matches. While it seems you can always bypass that users are confused. I had several questions about it already.

This PR adds a flag that allows for disabling of the external engine in favour of local one that seems to match the Ruby one.

It os **not** turned on by default to have backwards compatibility.