### PR TITLE
Introduce instance initialization callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Feature]** Oauthbearer token refresh callback (bruce-szalwinski-he)
 - [Enhancement] Replace time poll based wait engine with an event based to improve response times on blocking operations and wait (nijikon + mensfeld)
 - [Enhancement] Allow for usage of the second regex engine of librdkafka by setting `RDKAFKA_DISABLE_REGEX_EXT` during build (mensfeld)
+- [Enhancement] Introduce `rd_kafka_instance_created_callback` to be able to hook into the lifecycle of all the instance prior to the first polling.
 - [Change] The `wait_timeout` argument in `AbstractHandle.wait` method is deprecated and will be removed in future versions without replacement. We don't rely on it's value anymore (nijikon)
 - [Fix] Background logger stops working after forking causing memory leaks (mensfeld)
 


### PR DESCRIPTION
This PR introduces "yet another callback" so as not to break the current APIs.

Context: in case a producer or consumer, after creation, they immediately poll. This is expected, especially since the producer and admin use a background thread started automatically but this creates a chicken-and-egg issue where, for a multi-instance setup, there is no way to initialize and register the appropriate oauth handlers before first polling but after creation of rdkafka instance.

This is needed because otherwise, we get a callback with a name for which we did not register a handler. In theory, this could be handled by dynamically registering a new handler and injecting it, reserving the instance, but this is not good for any complex system where callbacks may be more advanced.

This callback aligns with the current clumsy way of doing things that should be replaced (and will be) by a proper instrumentation flow to ensure we do not break any APIs. It also matches other callback behaviors and the order of callable arguments.

Not perfect but gets things done within the current approach.