### PR TITLE
Allow for deferred native kafka start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Feature]** Oauthbearer token refresh callback (bruce-szalwinski-he)
 - [Enhancement] Replace time poll based wait engine with an event based to improve response times on blocking operations and wait (nijikon + mensfeld)
 - [Enhancement] Allow for usage of the second regex engine of librdkafka by setting `RDKAFKA_DISABLE_REGEX_EXT` during build (mensfeld)
+- [Change] Allow for native kafka thread operations deferring and manual start for consumer, producer and admin.
 - [Change] The `wait_timeout` argument in `AbstractHandle.wait` method is deprecated and will be removed in future versions without replacement. We don't rely on it's value anymore (nijikon)
 - [Fix] Background logger stops working after forking causing memory leaks (mensfeld)
 

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -12,6 +12,12 @@ module Rdkafka
       ObjectSpace.define_finalizer(self, native_kafka.finalizer)
     end
 
+    # Starts the native Kafka polling thread and kicks off the init polling
+    # @note Not needed to run unless explicit start was disabled
+    def start
+      @native_kafka.start
+    end
+
     def finalizer
       ->(_) { close }
     end

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -18,6 +18,13 @@ module Rdkafka
       @native_kafka.start
     end
 
+    # @return [String] admin name
+    def name
+      @name ||= @native_kafka.with_inner do |inner|
+        ::Rdkafka::Bindings.rd_kafka_name(inner)
+      end
+    end
+
     def finalizer
       ->(_) { close }
     end

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -195,11 +195,13 @@ module Rdkafka
 
     # Creates a consumer with this configuration.
     #
+    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Consumer] The created consumer
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def consumer
+    def consumer(native_kafka_start: true)
       opaque = Opaque.new
       config = native_config(opaque)
 
@@ -214,25 +216,26 @@ module Rdkafka
       # Redirect the main queue to the consumer queue
       Rdkafka::Bindings.rd_kafka_poll_set_consumer(kafka) if @consumer_poll_set
 
-      yield(kafka, Rdkafka::Bindings.rd_kafka_name(kafka)) if block_given?
-
       # Return consumer with Kafka client
       Rdkafka::Consumer.new(
         Rdkafka::NativeKafka.new(
           kafka,
           run_polling_thread: false,
-          opaque: opaque
+          opaque: opaque,
+          start: native_kafka_start
         )
       )
     end
 
     # Create a producer with this configuration.
     #
+    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Producer] The created producer
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def producer
+    def producer(native_kafka_start: true)
       # Create opaque
       opaque = Opaque.new
       # Create Kafka config
@@ -243,13 +246,13 @@ module Rdkafka
       partitioner_name = self[:partitioner] || self["partitioner"]
 
       kafka = native_kafka(config, :rd_kafka_producer)
-      yield(kafka, Rdkafka::Bindings.rd_kafka_name(kafka)) if block_given?
 
       Rdkafka::Producer.new(
         Rdkafka::NativeKafka.new(
           kafka,
           run_polling_thread: true,
-          opaque: opaque
+          opaque: opaque,
+          start: native_kafka_start
         ),
         partitioner_name
       ).tap do |producer|
@@ -259,23 +262,25 @@ module Rdkafka
 
     # Creates an admin instance with this configuration.
     #
+    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Admin] The created admin instance
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def admin
+    def admin(native_kafka_start: true)
       opaque = Opaque.new
       config = native_config(opaque)
       Rdkafka::Bindings.rd_kafka_conf_set_background_event_cb(config, Rdkafka::Callbacks::BackgroundEventCallbackFunction)
 
       kafka = native_kafka(config, :rd_kafka_producer)
-      yield(kafka, Rdkafka::Bindings.rd_kafka_name(kafka)) if block_given?
 
       Rdkafka::Admin.new(
         Rdkafka::NativeKafka.new(
           kafka,
           run_polling_thread: true,
-          opaque: opaque
+          opaque: opaque,
+          start: native_kafka_start
         )
       )
     end

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -195,13 +195,13 @@ module Rdkafka
 
     # Creates a consumer with this configuration.
     #
-    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    # @param native_kafka_auto_start [Boolean] should the native kafka operations be started
     #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Consumer] The created consumer
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def consumer(native_kafka_start: true)
+    def consumer(native_kafka_auto_start: true)
       opaque = Opaque.new
       config = native_config(opaque)
 
@@ -222,20 +222,20 @@ module Rdkafka
           kafka,
           run_polling_thread: false,
           opaque: opaque,
-          start: native_kafka_start
+          auto_start: native_kafka_auto_start
         )
       )
     end
 
     # Create a producer with this configuration.
     #
-    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    # @param native_kafka_auto_start [Boolean] should the native kafka operations be started
     #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Producer] The created producer
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def producer(native_kafka_start: true)
+    def producer(native_kafka_auto_start: true)
       # Create opaque
       opaque = Opaque.new
       # Create Kafka config
@@ -252,7 +252,7 @@ module Rdkafka
           kafka,
           run_polling_thread: true,
           opaque: opaque,
-          start: native_kafka_start
+          auto_start: native_kafka_auto_start
         ),
         partitioner_name
       ).tap do |producer|
@@ -262,13 +262,13 @@ module Rdkafka
 
     # Creates an admin instance with this configuration.
     #
-    # @param native_kafka_start [Boolean] should the native kafka operations be started
+    # @param native_kafka_auto_start [Boolean] should the native kafka operations be started
     #   automatically. Defaults to true. Set to false only when doing complex initialization.
     # @return [Admin] The created admin instance
     #
     # @raise [ConfigError] When the configuration contains invalid options
     # @raise [ClientCreationError] When the native client cannot be created
-    def admin(native_kafka_start: true)
+    def admin(native_kafka_auto_start: true)
       opaque = Opaque.new
       config = native_config(opaque)
       Rdkafka::Bindings.rd_kafka_conf_set_background_event_cb(config, Rdkafka::Callbacks::BackgroundEventCallbackFunction)
@@ -280,7 +280,7 @@ module Rdkafka
           kafka,
           run_polling_thread: true,
           opaque: opaque,
-          start: native_kafka_start
+          auto_start: native_kafka_auto_start
         )
       )
     end

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -20,6 +20,12 @@ module Rdkafka
       @native_kafka = native_kafka
     end
 
+    # Starts the native Kafka polling thread and kicks off the init polling
+    # @note Not needed to run unless explicit start was disabled
+    def start
+      @native_kafka.start
+    end
+
     # @return [String] consumer name
     def name
       @name ||= @native_kafka.with_inner do |inner|

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -4,7 +4,7 @@ module Rdkafka
   # @private
   # A wrapper around a native kafka that polls and cleanly exits
   class NativeKafka
-    def initialize(inner, run_polling_thread:, opaque:, start: true)
+    def initialize(inner, run_polling_thread:, opaque:, auto_start: true)
       @inner = inner
       @opaque = opaque
       # Lock around external access
@@ -30,7 +30,7 @@ module Rdkafka
 
       @run_polling_thread = run_polling_thread
 
-      self.start if start
+      start if auto_start
 
       @closing = false
     end

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -30,7 +30,7 @@ module Rdkafka
 
       @run_polling_thread = run_polling_thread
 
-      start if start
+      self.start if start
 
       @closing = false
     end

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -54,6 +54,12 @@ module Rdkafka
       end
     end
 
+    # Starts the native Kafka polling thread and kicks off the init polling
+    # @note Not needed to run unless explicit start was disabled
+    def start
+      @native_kafka.start
+    end
+
     # @return [String] producer name
     def name
       @name ||= @native_kafka.with_inner do |inner|

--- a/spec/rdkafka/admin_spec.rb
+++ b/spec/rdkafka/admin_spec.rb
@@ -31,6 +31,19 @@ describe Rdkafka::Admin do
   let(:operation)             {Rdkafka::Bindings::RD_KAFKA_ACL_OPERATION_READ}
   let(:permission_type)       {Rdkafka::Bindings::RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW}
 
+  describe 'admin without auto-start' do
+    let(:admin) { config.admin(native_kafka_auto_start: false) }
+
+    it 'expect to be able to start it later and close' do
+      admin.start
+      admin.close
+    end
+
+    it 'expect to be able to close it without starting' do
+      admin.close
+    end
+  end
+
   describe "#create_topic" do
     describe "called with invalid input" do
       describe "with an invalid topic name" do

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -14,6 +14,19 @@ describe Rdkafka::Consumer do
     it { expect(consumer.name).to include('rdkafka#consumer-') }
   end
 
+  describe 'consumer without auto-start' do
+    let(:consumer) { rdkafka_consumer_config.consumer(native_kafka_auto_start: false) }
+
+    it 'expect to be able to start it later and close' do
+      consumer.start
+      consumer.close
+    end
+
+    it 'expect to be able to close it without starting' do
+      consumer.close
+    end
+  end
+
   describe "#subscribe, #unsubscribe and #subscription" do
     it "should subscribe, unsubscribe and return the subscription" do
       expect(consumer.subscription).to be_empty

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -14,6 +14,19 @@ describe Rdkafka::Producer do
     consumer.close
   end
 
+  describe 'producer without auto-start' do
+    let(:producer) { rdkafka_producer_config.producer(native_kafka_auto_start: false) }
+
+    it 'expect to be able to start it later and close' do
+      producer.start
+      producer.close
+    end
+
+    it 'expect to be able to close it without starting' do
+      producer.close
+    end
+  end
+
   describe '#name' do
     it { expect(producer.name).to include('rdkafka#producer-') }
   end


### PR DESCRIPTION
This PR tackles https://github.com/karafka/rdkafka-ruby/pull/426 in a different way.

Instead of yielding, we allow for deferred start of producer/consumer/admin.

That way we can obtain full rdkafka-ruby object on which we can operate without resolving to the bindings and we can do complex initialization and only then actually start the requested operations.

This is much better than the yielding attempt for higher level frameworks that should not resolve to using bindings API directly but should rely on rdkafka-ruby abstractions.

This change is NOT breaking.

Note: I do NOT provide "not_started_check" in a similar manner to how we do close producer check, etc because this is a low-level API that is suppose to be used only by higher level libs devs.