### PR TITLE
Fix early return in NativeKafka#start

### DIFF
--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -37,7 +37,7 @@ module Rdkafka
 
     def start
       synchronize do
-        @return if @started
+        return if @started
 
         @started = true
 


### PR DESCRIPTION
I think this was a typo, and could potentially lead to creating multiple polling threads.

I'm investigating a segfault that I see in production during shutdown where `rd_kafka_poll` is crashing because `@inner` appears to be `nil`.