### PR TITLE
Fix bogus case/when syntax. Levels 1, 2, and 6 previously defaulted to UNKNOWN

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -124,13 +124,13 @@ module Rdkafka
       :void, [:pointer, :int, :string, :string]
     ) do |_client_ptr, level, _level_string, line|
       severity = case level
-                 when 0 || 1 || 2
+                 when 0, 1, 2
                    Logger::FATAL
                  when 3
                    Logger::ERROR
                  when 4
                    Logger::WARN
-                 when 5 || 6
+                 when 5, 6
                    Logger::INFO
                  when 7
                    Logger::DEBUG

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -36,6 +36,16 @@ describe Rdkafka::Bindings do
       expect(log_queue).to have_received(:<<).with([Logger::FATAL, "rdkafka: log line"])
     end
 
+    it "should log fatal messages" do
+      Rdkafka::Bindings::LogCallback.call(nil, 1, nil, "log line")
+      expect(log_queue).to have_received(:<<).with([Logger::FATAL, "rdkafka: log line"])
+    end
+
+    it "should log fatal messages" do
+      Rdkafka::Bindings::LogCallback.call(nil, 2, nil, "log line")
+      expect(log_queue).to have_received(:<<).with([Logger::FATAL, "rdkafka: log line"])
+    end
+
     it "should log error messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 3, nil, "log line")
       expect(log_queue).to have_received(:<<).with([Logger::ERROR, "rdkafka: log line"])
@@ -48,6 +58,11 @@ describe Rdkafka::Bindings do
 
     it "should log info messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 5, nil, "log line")
+      expect(log_queue).to have_received(:<<).with([Logger::INFO, "rdkafka: log line"])
+    end
+
+    it "should log info messages" do
+      Rdkafka::Bindings::LogCallback.call(nil, 6, nil, "log line")
       expect(log_queue).to have_received(:<<).with([Logger::INFO, "rdkafka: log line"])
     end
 


### PR DESCRIPTION
Ruby will evaluate expressions like `0 || 1 || 2` to the first truthy value before matching the `case`, so only level 0 would ever match the first case, etc.