### PR TITLE
Raise ArgumentError if nil passed to Consumer#subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0 (Unreleased)
 - [Enhancement] Update `librdkafka` to `2.4.0`
+- [Enhancement] Raise ArgumentError if a nil passed to Consumer#subscribe to prevent segfault and get informative error message (eugene-nikolaev)
 - [Feature] Add `#seek_by` to be able to seek for a message by topic, partition and offset (zinahia)
 
 ## 0.16.0 (2024-06-13)

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -63,6 +63,8 @@ module Rdkafka
     def subscribe(*topics)
       closed_consumer_check(__method__)
 
+      raise ArgumentError.new("'topics' should not contain nil") if topics.any?(&:nil?)
+
       # Create topic partition list with topics and no partition set
       tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(topics.length)
 

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -52,6 +52,13 @@ describe Rdkafka::Consumer do
       }.to raise_error(Rdkafka::RdkafkaError)
     end
 
+    it "should raise an error when a topic is nil" do
+      # otherwise a segfault happens in librdkafka - hard to troubleshoot
+      expect {
+        consumer.subscribe('test-topic', nil)
+      }.to raise_error(ArgumentError, "'topics' should not contain nil")
+    end
+
     it "should raise an error when unsubscribing fails" do
       expect(Rdkafka::Bindings).to receive(:rd_kafka_unsubscribe).and_return(20)
 


### PR DESCRIPTION
Hi!
I propose to add such a guard into `Consumer#subscribe`.
Otherwise such a call leads to a segfault in librdkafka which is confusing and hard to troubleshoot:

```
.../rdkafka-ruby/lib/rdkafka/consumer.rb:78: [BUG] Segmentation fault at 0x0000000000000000
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin22]

-- Crash Report log information --------------------------------------------
   See Crash Report log file in one of the following locations:             
     * ~/Library/Logs/DiagnosticReports                                     
     * /Library/Logs/DiagnosticReports                                      
   for more details.                                                        
Don't forget to include the above Crash Report log file in bug reports.     

-- Control frame information -----------------------------------------------
c:0070 p:---- s:0382 e:000381 CFUNC  :rd_kafka_subscribe
c:0069 p:0008 s:0376 e:000375 BLOCK  /Users/eugene/projects/rdkafka-ruby/lib/rdkafka/consumer.rb:78
c:0068 p:0044 s:0372 e:000371 METHOD /Users/eugene/projects/rdkafka-ruby/lib/rdkafka/native_kafka.rb:77
c:0067 p:0049 s:0368 e:000367 METHOD /Users/eugene/projects/rdkafka-ruby/lib/rdkafka/consumer.rb:77
<hundreds of lines below>
```

That could save a lot of time of the library users.
I've spent half a day after mistakenly putting a nil there, which is very easy to do in ruby for multiple reasons :) Mine was a wrong instance variable name which was for sure undefined and dereferenced to a nil. That does not raise any error by itself.

If you're fine with that - please feel free to propose more apropriate/uniform textings or whatever.