### PR TITLE
do not release gvl on memory read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.18.0 (Unreleased)
 - [Enhancement] Update `librdkafka` to `2.5.0`
+- [Enhancement] Do not release GVL on `rd_kafka_name` (ferrous26)
 - [Patch] Patch cooperative-sticky assignments in librdkafka.
 - [Fix] Mitigate a case where FFI would not restart the background events callback dispatcher in forks
 - [Fix] Fix unused variable reference in producer (lucasmvnascimento)

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -38,7 +38,7 @@ module Rdkafka
 
     # Metadata
 
-    attach_function :rd_kafka_name, [:pointer], :string, blocking: true
+    attach_function :rd_kafka_name, [:pointer], :string
     attach_function :rd_kafka_memberid, [:pointer], :string, blocking: true
     attach_function :rd_kafka_clusterid, [:pointer], :string, blocking: true
     attach_function :rd_kafka_metadata, [:pointer, :int, :pointer, :pointer, :int], :int, blocking: true


### PR DESCRIPTION
backport from https://github.com/karafka/karafka-rdkafka/pull/117/files