### PR TITLE
use default oauth callback if none is passed

### DIFF
--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -338,7 +338,9 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_conf_set_error_cb(config, Rdkafka::Bindings::ErrorCallback)
 
         # Set oauth callback
-        Rdkafka::Bindings.rd_kafka_conf_set_oauthbearer_token_refresh_cb(config, Rdkafka::Bindings::OAuthbearerTokenRefreshCallback)
+        if Rdkafka::Config.oauthbearer_token_refresh_callback
+          Rdkafka::Bindings.rd_kafka_conf_set_oauthbearer_token_refresh_cb(config, Rdkafka::Bindings::OAuthbearerTokenRefreshCallback)
+        end
       end
     end
 


### PR DESCRIPTION
resolves #505.

I've tested this locally and confirmed that it works. 