### PR TITLE
Remove Ruby 3.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
-## 0.18.1 (Unreleased)
+## 0.19.0 (Unreleased)
+- **[Breaking]** Drop Ruby 3.0 support
 - [Enhancement] Use default oauth callback if none is passed (bachmanity1)
 - [Fix] Fix incorrectly behaving CI on failures. 
 - [Patch] Patch with "Add forward declaration to fix compilation without ssl" fix

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ bundle exec rake produce_messages
 
 | rdkafka-ruby | librdkafka | patches |
 |-|-|-|
+| 0.19.0 (Unreleased) | 2.5.0 (2024-06-10) | yes |
 | 0.18.0 (2024-09-02) | 2.5.0 (2024-06-10) | yes |
 | 0.17.0 (2024-08-03) | 2.4.0 (2024-05-07) | no  |
 | 0.16.0 (2024-06-13) | 2.3.0 (2023-10-25) | no  |

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.18.1"
+  VERSION = "0.19.0"
   LIBRDKAFKA_VERSION = "2.5.0"
   LIBRDKAFKA_SOURCE_SHA256 = "3dc62de731fd516dfb1032861d9a580d4d0b5b0856beb0f185d06df8e6c26259"
 end

--- a/rdkafka.gemspec
+++ b/rdkafka.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name = 'rdkafka'
   gem.require_paths = ['lib']
   gem.version = Rdkafka::VERSION
-  gem.required_ruby_version = '>= 3.0'
+  gem.required_ruby_version = '>= 3.1'
   gem.extensions = %w(ext/Rakefile)
   gem.cert_chain = %w[certs/cert.pem]
 


### PR DESCRIPTION
As discussed removing Ruby 3.0 as it's way after EOL and blocks some further performance work.