### PR TITLE
build on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,24 @@ jobs:
           cd ext && bundle exec rake
           cd ..
           bundle exec rspec
+
+
+  macos_build:
+    timeout-minutes: 30
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.4'
+          - '3.3'
+          - '3.2'
+          - '3.1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,12 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: false
+
+      - name: Run all specs
+        env:
+          GITHUB_COVERAGE: ${{matrix.coverage}}
+
+        run: |
+          set -e
+          bundle install --path vendor/bundle
+          cd ext && bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,7 @@ jobs:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: false
 
-      - name: Run all specs
-        env:
-          GITHUB_COVERAGE: ${{matrix.coverage}}
-
+      - name: Build rdkafka-ruby
         run: |
           set -e
           bundle install --path vendor/bundle


### PR DESCRIPTION
since it's not possible to run docker atm (or super hard) as of now to tackle https://github.com/karafka/rdkafka-ruby/issues/532 lets at least build on macos to ensure stability.

For CI execution I have a mac mini in my home lab which should be sufficient.