### PR TITLE
allow key and partition key on new topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
 ## 0.21.1 (Unreleased)
+- [Enhancement] Allow for producing to non-existing topics with `key` and `partition_key` present.
 - [Enhancement] Replace TTL-based partition count cache with a global cache that reuses `librdkafka` statistics data when possible.
 - [Enhancement] Support producing and consuming of headers with mulitple values (KIP-82).
 - [Enhancement] Allow native Kafka customization poll time.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -239,6 +239,13 @@ module Rdkafka
 
         topic_metadata ? topic_metadata[:partition_count] : -1
       end
+    rescue Rdkafka::RdkafkaError => e
+      # If the topic does not exist, it will be created or if not allowed another error will be
+      # raised. We here return -1 so this can happen without early error happening on metadata
+      # discovery.
+      return -1 if e.code == :unknown_topic_or_part
+
+      raise(e)
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.


### PR DESCRIPTION
This PR allows us to work with new (to be created) topics with a key and a partition key being used. We catch the error on metadata discovery and use -1, so the topic can be created (if permissions allow).

If permissions do not allow (auto creation off) it will raise a correct error down the road.