### PR TITLE
fix null pointer reference segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[Feature]** Add precompiled `x86_64-linux-musl` setup.
 - **[Feature]** Add precompiled `macos_arm64` setup.
 - [Fix] Fix a case where using empty key on the `musl` architecture would cause a segfault.
+- [Fix] Fix for null pointer reference bypass on empty string being too wide causing segfault.
 - [Enhancement] Allow for producing to non-existing topics with `key` and `partition_key` present.
 - [Enhancement] Replace TTL-based partition count cache with a global cache that reuses `librdkafka` statistics data when possible.
 - [Enhancement] Support producing and consuming of headers with mulitple values (KIP-82).

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -384,18 +384,16 @@ module Rdkafka
       hsh[name] = method_name
     end
 
-    def self.partitioner(str, partition_count, partitioner_name = "consistent_random")
+    def self.partitioner(topic_ptr, str, partition_count, partitioner = "consistent_random")
       # Return RD_KAFKA_PARTITION_UA(unassigned partition) when partition count is nil/zero.
       return -1 unless partition_count&.nonzero?
-      # musl architecture crashes with empty string
-      return 0 if str.empty?
 
-      str_ptr = FFI::MemoryPointer.from_string(str)
-      method_name = PARTITIONERS.fetch(partitioner_name) do
-        raise Rdkafka::Config::ConfigError.new("Unknown partitioner: #{partitioner_name}")
+      str_ptr = str.empty? ? FFI::MemoryPointer::NULL : FFI::MemoryPointer.from_string(str)
+      method_name = PARTITIONERS.fetch(partitioner) do
+        raise Rdkafka::Config::ConfigError.new("Unknown partitioner: #{partitioner}")
       end
 
-      public_send(method_name, nil, str_ptr, str.size, partition_count, nil, nil)
+      public_send(method_name, topic_ptr, str_ptr, str.size, partition_count, nil, nil)
     end
 
     # Create Topics

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -51,13 +51,13 @@ module Rdkafka
 
     # @private
     # @param native_kafka [NativeKafka]
-    # @param partitioner_name [String, nil] name of the partitioner we want to use or nil to use
+    # @param partitioner [String, nil] name of the partitioner we want to use or nil to use
     #   the "consistent_random" default
-    def initialize(native_kafka, partitioner_name)
+    def initialize(native_kafka, partitioner)
       @topics_refs_map = {}
       @topics_configs = {}
       @native_kafka = native_kafka
-      @partitioner_name = partitioner_name || "consistent_random"
+      @partitioner = partitioner || "consistent_random"
 
       # Makes sure, that native kafka gets closed before it gets GCed by Ruby
       ObjectSpace.define_finalizer(self, native_kafka.finalizer)
@@ -275,7 +275,8 @@ module Rdkafka
       timestamp: nil,
       headers: nil,
       label: nil,
-      topic_config: EMPTY_HASH
+      topic_config: EMPTY_HASH,
+      partitioner: @partitioner
     )
       closed_producer_check(__method__)
 
@@ -307,10 +308,14 @@ module Rdkafka
 
         # Check if there are no overrides for the partitioner and use the default one only when
         # no per-topic is present.
-        partitioner_name = @topics_configs.dig(topic, topic_config_hash, :partitioner) || @partitioner_name
+        selected_partitioner = @topics_configs.dig(topic, topic_config_hash, :partitioner) || partitioner
 
         # If the topic is not present, set to -1
-        partition = Rdkafka::Bindings.partitioner(partition_key, partition_count, partitioner_name) if partition_count.positive?
+        partition = Rdkafka::Bindings.partitioner(
+          topic_ref,
+          partition_key,
+          partition_count,
+          selected_partitioner) if partition_count.positive?
       end
 
       # If partition is nil, use -1 to let librdafka set the partition randomly or

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -77,30 +77,6 @@ describe Rdkafka::Bindings do
     end
   end
 
-  describe "partitioner" do
-    let(:partition_key) { ('a'..'z').to_a.shuffle.take(15).join('') }
-    let(:partition_count) { rand(50) + 1 }
-
-    it "should return the same partition for a similar string and the same partition count" do
-      result_1 = Rdkafka::Bindings.partitioner(partition_key, partition_count)
-      result_2 = Rdkafka::Bindings.partitioner(partition_key, partition_count)
-      expect(result_1).to eq(result_2)
-    end
-
-    it "should match the old partitioner" do
-      result_1 = Rdkafka::Bindings.partitioner(partition_key, partition_count)
-      result_2 = (Zlib.crc32(partition_key) % partition_count)
-      expect(result_1).to eq(result_2)
-    end
-
-    it "should return the partition calculated by the specified partitioner" do
-      result_1 = Rdkafka::Bindings.partitioner(partition_key, partition_count, "murmur2")
-      ptr = FFI::MemoryPointer.from_string(partition_key)
-      result_2 = Rdkafka::Bindings.rd_kafka_msg_partitioner_murmur2(nil, ptr, partition_key.size, partition_count, nil, nil)
-      expect(result_1).to eq(result_2)
-    end
-  end
-
   describe "stats callback" do
     context "without a stats callback" do
       it "should do nothing" do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -920,7 +920,6 @@ describe Rdkafka::Producer do
     end
   end
 
-
   describe 'with active statistics callback' do
     let(:producer) do
       rdkafka_producer_config('statistics.interval.ms': 1_000).producer
@@ -1058,7 +1057,7 @@ describe Rdkafka::Producer do
       it "should not return partition 0 for all partitioners" do
         test_key = "test-key-123"
         results = {}
-        
+
         all_partitioners.each do |partitioner|
           handle = producer.produce(
             topic: "partitioner_test_topic",
@@ -1066,17 +1065,14 @@ describe Rdkafka::Producer do
             partition_key: test_key,
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           results[partitioner] = report.partition
-          
-          puts "#{partitioner}: #{test_key} -> partition #{report.partition}"
         end
-        
+
         # Should not all be the same partition (especially not all 0)
         unique_partitions = results.values.uniq
-        expect(unique_partitions.size).to be > 1, 
-               "All partitioners returned same partition! Results: #{results}"
+        expect(unique_partitions.size).to be > 1
       end
     end
 
@@ -1092,9 +1088,7 @@ describe Rdkafka::Producer do
           )
 
           report = handle.wait(max_wait_timeout: 5)
-          expect(report.partition).to  be >= 0
-
-          puts "#{partitioner}: empty string -> partition #{report.partition}"
+          expect(report.partition).to be >= 0
         end
       end
     end
@@ -1107,7 +1101,7 @@ describe Rdkafka::Producer do
           key: "test-key",
           partition_key: nil
         )
-        
+
         report = handle.wait(max_wait_timeout: 5)
         expect(report.partition).to be >= 0
         expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
@@ -1123,18 +1117,16 @@ describe Rdkafka::Producer do
             partition_key: "a",
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: short key 'a' -> partition #{report.partition}"
         end
       end
 
       it "should handle very long keys with all partitioners" do
         long_key = "a" * 1000
-        
+
         all_partitioners.each do |partitioner|
           handle = producer.produce(
             topic: "partitioner_test_topic",
@@ -1142,18 +1134,16 @@ describe Rdkafka::Producer do
             partition_key: long_key,
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: long key -> partition #{report.partition}"
         end
       end
 
       it "should handle unicode keys with all partitioners" do
         unicode_key = "测试键值🚀"
-        
+
         all_partitioners.each do |partitioner|
           handle = producer.produce(
             topic: "partitioner_test_topic",
@@ -1161,12 +1151,10 @@ describe Rdkafka::Producer do
             partition_key: unicode_key,
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: unicode key -> partition #{report.partition}"
         end
       end
     end
@@ -1175,7 +1163,7 @@ describe Rdkafka::Producer do
       %w(consistent murmur2 fnv1a).each do |partitioner|
         it "should consistently route same partition key to same partition with #{partitioner}" do
           partition_key = "consistent-test-key"
-          
+
           # Produce multiple messages with same partition key
           reports = 5.times.map do
             handle = producer.produce(
@@ -1186,13 +1174,10 @@ describe Rdkafka::Producer do
             )
             handle.wait(max_wait_timeout: 5)
           end
-          
+
           # All should go to same partition
           partitions = reports.map(&:partition).uniq
-          expect(partitions.size).to eq(1), 
-                 "#{partitioner}: Expected all messages to go to same partition, got: #{partitions}"
-          
-          puts "#{partitioner}: consistent key -> always partition #{partitions.first}"
+          expect(partitions.size).to eq(1)
         end
       end
     end
@@ -1202,7 +1187,7 @@ describe Rdkafka::Producer do
         it "should potentially distribute across partitions with #{partitioner}" do
           # Note: random partitioners might still return same value by chance
           partition_key = "random-test-key"
-          
+
           reports = 10.times.map do
             handle = producer.produce(
               topic: "partitioner_test_topic",
@@ -1212,10 +1197,9 @@ describe Rdkafka::Producer do
             )
             handle.wait(max_wait_timeout: 5)
           end
-          
+
           partitions = reports.map(&:partition)
-          puts "#{partitioner}: random distribution -> #{partitions}"
-          
+
           # Just ensure they're valid partitions
           partitions.each do |partition|
             expect(partition).to be >= 0
@@ -1228,7 +1212,7 @@ describe Rdkafka::Producer do
     context "comparing different partitioners with same key" do
       it "should route different partition keys to potentially different partitions" do
         keys = ["key1", "key2", "key3", "key4", "key5"]
-        
+
         all_partitioners.each do |partitioner|
           reports = keys.map do |key|
             handle = producer.produce(
@@ -1239,10 +1223,9 @@ describe Rdkafka::Producer do
             )
             handle.wait(max_wait_timeout: 5)
           end
-          
+
           partitions = reports.map(&:partition).uniq
-          puts "#{partitioner}: keys #{keys} -> partitions #{partitions}"
-          
+
           # Should distribute across multiple partitions for most partitioners
           # (though some might hash all keys to same partition by chance)
           expect(partitions.all? { |p| p >= 0 && p < producer.partition_count("partitioner_test_topic") }).to be true
@@ -1255,7 +1238,7 @@ describe Rdkafka::Producer do
         # Use keys that would hash to different partitions
         regular_key = "regular-key-123"
         partition_key = "partition-key-456"
-        
+
         # Message with both keys
         handle1 = producer.produce(
           topic: "partitioner_test_topic",
@@ -1263,28 +1246,28 @@ describe Rdkafka::Producer do
           key: regular_key,
           partition_key: partition_key
         )
-        
+
         # Message with only partition key (should go to same partition)
         handle2 = producer.produce(
           topic: "partitioner_test_topic",
           payload: "test payload 2",
           partition_key: partition_key
         )
-        
+
         # Message with only regular key (should go to different partition)
         handle3 = producer.produce(
           topic: "partitioner_test_topic",
           payload: "test payload 3",
           key: regular_key
         )
-        
+
         report1 = handle1.wait(max_wait_timeout: 5)
         report2 = handle2.wait(max_wait_timeout: 5)
         report3 = handle3.wait(max_wait_timeout: 5)
-        
+
         # Messages 1 and 2 should go to same partition (both use partition_key)
         expect(report1.partition).to eq(report2.partition)
-        
+
         # Message 3 should potentially go to different partition (uses regular key)
         expect(report3.partition).not_to eq(report1.partition)
       end
@@ -1300,12 +1283,10 @@ describe Rdkafka::Producer do
             partition_key: nil,
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: nil partition_key -> partition #{report.partition}"
         end
       end
 
@@ -1317,12 +1298,10 @@ describe Rdkafka::Producer do
             partition_key: "   ",
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: whitespace key -> partition #{report.partition}"
         end
       end
 
@@ -1334,12 +1313,10 @@ describe Rdkafka::Producer do
             partition_key: "key\nwith\nnewlines",
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
           expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
-          
-          puts "#{partitioner}: newline key -> partition #{report.partition}"
         end
       end
     end
@@ -1348,7 +1325,7 @@ describe Rdkafka::Producer do
       it "should show if all partitioners return 0 (indicating a problem)" do
         test_key = "debug-test-key"
         zero_count = 0
-        
+
         all_partitioners.each do |partitioner|
           handle = producer.produce(
             topic: "partitioner_test_topic",
@@ -1356,20 +1333,12 @@ describe Rdkafka::Producer do
             partition_key: test_key,
             partitioner: partitioner
           )
-          
+
           report = handle.wait(max_wait_timeout: 5)
           zero_count += 1 if report.partition == 0
-          
-          puts "DEBUG #{partitioner}: '#{test_key}' -> partition #{report.partition}"
         end
-        
-        if zero_count == all_partitioners.size
-          puts "WARNING: All partitioners returned partition 0 - possible issue with FFI bindings!"
-        end
-        
-        # This test will fail if there's a real issue
-        expect(zero_count).to be < all_partitioners.size, 
-               "All #{all_partitioners.size} partitioners returned partition 0 - FFI binding issue suspected"
+
+        expect(zero_count).to be < all_partitioners.size
       end
     end
   end


### PR DESCRIPTION
This PR:

- fixes segfault that was a long-lasting bug caused by passing null reference to a state-aware partitioners
- extends the producer API to allow for per-message partitioner value

close https://github.com/karafka/rdkafka-ruby/issues/635