### PR TITLE
Disable RSpec monkey patching

### DIFF
--- a/spec/lib/rdkafka/abstract_handle_spec.rb
+++ b/spec/lib/rdkafka/abstract_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::AbstractHandle do
+RSpec.describe Rdkafka::AbstractHandle do
   let(:response) { 0 }
   let(:result) { -1 }
 

--- a/spec/lib/rdkafka/admin/create_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/create_acl_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::CreateAclHandle do
+RSpec.describe Rdkafka::Admin::CreateAclHandle do
   # If create acl was successful there is no error object
   # the error code is set to RD_KAFKA_RESP_ERR_NO_ERRORa
   # https://github.com/confluentinc/librdkafka/blob/1f9f245ac409f50f724695c628c7a0d54a763b9a/src/rdkafka_error.c#L169

--- a/spec/lib/rdkafka/admin/create_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/create_acl_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::CreateAclReport do
+RSpec.describe Rdkafka::Admin::CreateAclReport do
   subject { Rdkafka::Admin::CreateAclReport.new(
       rdkafka_response: Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR,
       rdkafka_response_string: FFI::MemoryPointer.from_string("")

--- a/spec/lib/rdkafka/admin/create_topic_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/create_topic_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::CreateTopicHandle do
+RSpec.describe Rdkafka::Admin::CreateTopicHandle do
   let(:response) { 0 }
   let(:topic_name) { TestTopics.unique }
 

--- a/spec/lib/rdkafka/admin/create_topic_report_spec.rb
+++ b/spec/lib/rdkafka/admin/create_topic_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::CreateTopicReport do
+RSpec.describe Rdkafka::Admin::CreateTopicReport do
   subject { Rdkafka::Admin::CreateTopicReport.new(
       FFI::MemoryPointer.from_string("error string"),
       FFI::MemoryPointer.from_string("result name")

--- a/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DeleteAclHandle do
+RSpec.describe Rdkafka::Admin::DeleteAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
   let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}

--- a/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DeleteAclReport do
+RSpec.describe Rdkafka::Admin::DeleteAclReport do
   let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}

--- a/spec/lib/rdkafka/admin/delete_topic_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_topic_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DeleteTopicHandle do
+RSpec.describe Rdkafka::Admin::DeleteTopicHandle do
   let(:response) { 0 }
   let(:topic_name) { TestTopics.unique }
 

--- a/spec/lib/rdkafka/admin/delete_topic_report_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_topic_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DeleteTopicReport do
+RSpec.describe Rdkafka::Admin::DeleteTopicReport do
   subject { Rdkafka::Admin::DeleteTopicReport.new(
       FFI::MemoryPointer.from_string("error string"),
       FFI::MemoryPointer.from_string("result name")

--- a/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DescribeAclHandle do
+RSpec.describe Rdkafka::Admin::DescribeAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
   let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}

--- a/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Admin::DescribeAclReport do
+RSpec.describe Rdkafka::Admin::DescribeAclReport do
 
   let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -2,7 +2,7 @@
 
 require "ostruct"
 
-describe Rdkafka::Admin do
+RSpec.describe Rdkafka::Admin do
   let(:config) { rdkafka_config }
   let(:admin)  { config.admin }
 

--- a/spec/lib/rdkafka/bindings_spec.rb
+++ b/spec/lib/rdkafka/bindings_spec.rb
@@ -2,7 +2,7 @@
 
 require 'zlib'
 
-describe Rdkafka::Bindings do
+RSpec.describe Rdkafka::Bindings do
   it "should load librdkafka" do
     expect(Rdkafka::Bindings.ffi_libraries.map(&:name).first).to include "librdkafka"
   end

--- a/spec/lib/rdkafka/callbacks_spec.rb
+++ b/spec/lib/rdkafka/callbacks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Callbacks do
+RSpec.describe Rdkafka::Callbacks do
 
   # The code in the call back functions is 100% covered by other specs.  Due to
   # the large number of collaborators, and the fact that FFI does not play

--- a/spec/lib/rdkafka/config_spec.rb
+++ b/spec/lib/rdkafka/config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Config do
+RSpec.describe Rdkafka::Config do
   context "logger" do
     it "should have a default logger" do
       expect(Rdkafka::Config.logger).to be_a Logger

--- a/spec/lib/rdkafka/consumer/headers_spec.rb
+++ b/spec/lib/rdkafka/consumer/headers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Consumer::Headers do
+RSpec.describe Rdkafka::Consumer::Headers do
   let(:headers) do
     { # Note String keys!
       "version" => ["2.1.3", "2.1.4"],

--- a/spec/lib/rdkafka/consumer/message_spec.rb
+++ b/spec/lib/rdkafka/consumer/message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Consumer::Message do
+RSpec.describe Rdkafka::Consumer::Message do
   let(:native_client) { new_native_client }
   let(:native_topic) { new_native_topic(native_client: native_client) }
   let(:payload) { nil }

--- a/spec/lib/rdkafka/consumer/partition_spec.rb
+++ b/spec/lib/rdkafka/consumer/partition_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Consumer::Partition do
+RSpec.describe Rdkafka::Consumer::Partition do
   let(:offset) { 100 }
   let(:err) { 0 }
   subject { Rdkafka::Consumer::Partition.new(1, offset, err) }

--- a/spec/lib/rdkafka/consumer/topic_partition_list_spec.rb
+++ b/spec/lib/rdkafka/consumer/topic_partition_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Consumer::TopicPartitionList do
+RSpec.describe Rdkafka::Consumer::TopicPartitionList do
   it "should create a new list and add unassigned topics" do
     list = Rdkafka::Consumer::TopicPartitionList.new
 

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -3,7 +3,7 @@
 require "ostruct"
 require 'securerandom'
 
-describe Rdkafka::Consumer do
+RSpec.describe Rdkafka::Consumer do
   let(:consumer) { rdkafka_consumer_config.consumer }
   let(:producer) { rdkafka_producer_config.producer }
 

--- a/spec/lib/rdkafka/error_spec.rb
+++ b/spec/lib/rdkafka/error_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::RdkafkaError do
+RSpec.describe Rdkafka::RdkafkaError do
   it "should raise a type error for a nil response" do
     expect {
       Rdkafka::RdkafkaError.new(nil)
@@ -88,7 +88,7 @@ describe Rdkafka::RdkafkaError do
   end
 end
 
-describe Rdkafka::LibraryLoadError do
+RSpec.describe Rdkafka::LibraryLoadError do
   it "should be a subclass of BaseError" do
     expect(Rdkafka::LibraryLoadError.new).to be_a(Rdkafka::BaseError)
   end

--- a/spec/lib/rdkafka/metadata_spec.rb
+++ b/spec/lib/rdkafka/metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require "securerandom"
 
-describe Rdkafka::Metadata do
+RSpec.describe Rdkafka::Metadata do
   let(:config)        { rdkafka_consumer_config }
   let(:native_config) { config.send(:native_config) }
   let(:native_kafka)  { config.send(:native_kafka, native_config, :rd_kafka_consumer) }

--- a/spec/lib/rdkafka/native_kafka_spec.rb
+++ b/spec/lib/rdkafka/native_kafka_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::NativeKafka do
+RSpec.describe Rdkafka::NativeKafka do
   let(:config) { rdkafka_producer_config }
   let(:native) { config.send(:native_kafka, config.send(:native_config), :rd_kafka_producer) }
   let(:closing) { false }

--- a/spec/lib/rdkafka/producer/delivery_handle_spec.rb
+++ b/spec/lib/rdkafka/producer/delivery_handle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Producer::DeliveryHandle do
+RSpec.describe Rdkafka::Producer::DeliveryHandle do
   let(:response) { 0 }
 
   subject do

--- a/spec/lib/rdkafka/producer/delivery_report_spec.rb
+++ b/spec/lib/rdkafka/producer/delivery_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Rdkafka::Producer::DeliveryReport do
+RSpec.describe Rdkafka::Producer::DeliveryReport do
   let(:topic_name) { TestTopics.unique }
   subject { Rdkafka::Producer::DeliveryReport.new(2, 100, topic_name, -1) }
 

--- a/spec/lib/rdkafka/producer_spec.rb
+++ b/spec/lib/rdkafka/producer_spec.rb
@@ -2,7 +2,7 @@
 
 require "zlib"
 
-describe Rdkafka::Producer do
+RSpec.describe Rdkafka::Producer do
   let(:producer) { rdkafka_producer_config.producer }
   let(:consumer) { rdkafka_consumer_config.consumer }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,6 +218,8 @@ def notify_listener(listener, &block)
 end
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
+
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
## Summary
- Add `config.disable_monkey_patching!` to `spec_helper.rb`
- Update all 27 spec files to use explicit `RSpec.describe` instead of the monkey-patched `describe`

Closes #620

## Test plan
- [x] All 425 specs pass with 0 failures
- [x] Code coverage remains at 97.25%