### PR TITLE
Add queue_size method to Producer

### DIFF
--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -212,6 +212,32 @@ module Rdkafka
       true
     end
 
+    # Returns the number of messages and requests waiting to be sent to the broker as well as
+    # delivery reports queued for the application.
+    #
+    # This provides visibility into the producer's internal queue depth, useful for:
+    # - Monitoring producer backpressure
+    # - Implementing custom flow control
+    # - Debugging message delivery issues
+    # - Graceful shutdown logic (wait until queue is empty)
+    #
+    # @return [Integer] the number of messages in the queue
+    # @raise [Rdkafka::ClosedProducerError] if called on a closed producer
+    #
+    # @note This method is thread-safe as it uses the @native_kafka.with_inner synchronization
+    #
+    # @example
+    #   producer.queue_size #=> 42
+    def queue_size
+      closed_producer_check(__method__)
+
+      @native_kafka.with_inner do |inner|
+        Rdkafka::Bindings.rd_kafka_outq_len(inner)
+      end
+    end
+
+    alias queue_length queue_size
+
     # Partition count for a given topic.
     #
     # @param topic [String] The topic name.

--- a/spec/lib/rdkafka/producer_spec.rb
+++ b/spec/lib/rdkafka/producer_spec.rb
@@ -642,13 +642,17 @@ RSpec.describe Rdkafka::Producer do
     end
 
     # Affected methods and a non-invalid set of parameters for the method
+    # :no_args indicates the method takes no arguments
     {
         :produce         => { topic: nil },
         :partition_count => nil,
+        :queue_size      => :no_args,
     }.each do |method, args|
       it "raises an exception if #{method} is called" do
         expect {
-          if args.is_a?(Hash)
+          if args == :no_args
+            producer.public_send(method)
+          elsif args.is_a?(Hash)
             producer.public_send(method, **args)
           else
             producer.public_send(method, args)
@@ -870,6 +874,58 @@ RSpec.describe Rdkafka::Producer do
           # queue purge
           expect(delivery_reports[0].error).to eq(-152)
         end
+      end
+    end
+  end
+
+  describe '#queue_size' do
+    it 'returns 0 when there are no pending messages' do
+      expect(producer.queue_size).to eq(0)
+    end
+
+    it 'returns a positive number when there are pending messages' do
+      # Use a producer that can't connect to ensure messages stay in queue
+      slow_producer = rdkafka_producer_config(
+        "bootstrap.servers": "127.0.0.1:9095",
+        "message.timeout.ms": 10_000
+      ).producer
+
+      begin
+        10.times do
+          slow_producer.produce(
+            topic: TestTopics.produce_test_topic,
+            payload: "test payload"
+          )
+        end
+
+        # Give some time for messages to be queued
+        sleep(0.1)
+
+        queue_size = slow_producer.queue_size
+        expect(queue_size).to be > 0
+      ensure
+        slow_producer.close
+      end
+    end
+
+    it 'returns 0 after flush completes' do
+      producer.produce(
+        topic: TestTopics.produce_test_topic,
+        payload: "test payload"
+      ).wait(max_wait_timeout_ms: 5_000)
+
+      producer.flush(5_000)
+
+      expect(producer.queue_size).to eq(0)
+    end
+
+    describe '#queue_length alias' do
+      it 'is an alias for queue_size' do
+        expect(producer.method(:queue_length)).to eq(producer.method(:queue_size))
+      end
+
+      it 'returns the same value as queue_size' do
+        expect(producer.queue_length).to eq(producer.queue_size)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add `#queue_size` method to `Rdkafka::Producer` that returns the number of messages waiting in the librdkafka output queue
- Add `#queue_length` as an alias for `#queue_size`
- Add comprehensive specs for the new method

## Details

This provides visibility into the producer's internal queue depth, useful for:
- Monitoring producer backpressure
- Implementing custom flow control
- Debugging message delivery issues
- Graceful shutdown logic (wait until queue is empty)

The method wraps the existing `rd_kafka_outq_len` FFI binding and follows the same patterns as other producer methods (closed producer check, thread-safe via `@native_kafka.with_inner`).

Extracted from WaterDrop patches.

## Test plan

- [x] Verify `queue_size` returns 0 when no pending messages
- [x] Verify `queue_size` returns positive value when messages are queued
- [x] Verify `queue_size` returns 0 after flush completes
- [x] Verify `queue_length` alias works correctly
- [x] Verify closed producer raises `ClosedProducerError`