### PR TITLE
Update Ruby 4.0.0-preview2 to Ruby 4.0 in CI workflows

### DIFF
--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
@@ -22,7 +22,7 @@
 # - Validates that removing build tools doesn't break precompiled usage
 #
 # EXTENDED COMPATIBILITY TESTING:
-# - Edge case Ruby versions: 4.0.0-preview2, JRuby-10.0 on ARM64
+# - Edge case Ruby versions: 4.0, JRuby-10.0 on ARM64
 # - Integration specs testing system library compatibility
 # - Both compilation and precompiled flows for comprehensive coverage
 # - Cross-platform compatibility validation for aarch64 architecture
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -197,7 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
@@ -21,7 +21,7 @@
 # - Validates that removing build tools doesn't break precompiled usage
 #
 # EXTENDED COMPATIBILITY TESTING:
-# - Edge case Ruby versions: 4.0.0-preview2, JRuby-10.0
+# - Edge case Ruby versions: 4.0, JRuby-10.0
 # - Integration specs testing system library compatibility
 # - Both compilation and precompiled flows for comprehensive coverage
 # - Cross-platform compatibility validation
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/.github/workflows/ci_macos_arm64.yml
+++ b/.github/workflows/ci_macos_arm64.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -38,7 +38,7 @@ jobs:
             macos-version: 'macos-15'
             coverage: 'true'
         exclude:
-          - ruby: '4.0.0-preview2'
+          - ruby: '4.0'
             macos-version: 'macos-14'
     runs-on: ${{ matrix.macos-version }}
     steps:
@@ -169,7 +169,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '4.0.0-preview2'
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'
@@ -181,7 +181,7 @@ jobs:
             macos-version: 'macos-15'
             coverage: 'true'
         exclude:
-          - ruby: '4.0.0-preview2'
+          - ruby: '4.0'
             macos-version: 'macos-14'
     runs-on: ${{ matrix.macos-version }}
     steps:


### PR DESCRIPTION
## Summary
- Update all CI workflow files to use Ruby 4.0 instead of 4.0.0-preview2
- Ruby 4.0 is now stable and available via ruby/setup-ruby

## Files Updated
- `ci_linux_ubuntu_x86_64_gnu.yml`
- `ci_linux_ubuntu_aarch64_gnu.yml`
- `ci_macos_arm64.yml`
- `ci_linux_ubuntu_x86_64_gnu_complementary.yml`
- `ci_linux_ubuntu_aarch64_gnu_complementary.yml`

## Test plan
- [ ] CI workflows run successfully with Ruby 4.0