### PR TITLE
Extract linting tools to separate Gemfile

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,6 +31,8 @@ jobs:
   yard_lint:
     name: YARD Documentation Lint
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: Gemfile.lint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,4 @@ group :development do
   gem 'rspec'
   gem 'simplecov'
   gem 'warning'
-  gem 'yard-lint', '~> 1.3.0'
 end

--- a/Gemfile.lint
+++ b/Gemfile.lint
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Documentation linting
+gem 'yard-lint'

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    yard (0.9.38)
+    yard-lint (1.4.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.6)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  yard-lint
+
+CHECKSUMS
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "7 days",
+  "includePaths": [
+    "Gemfile",
+    "Gemfile.lint",
+    ".github/workflows/**"
+  ],
   "github-actions": {
     "enabled": true,
     "pinDigests": true


### PR DESCRIPTION
## Summary

- Move `yard-lint` to a separate `Gemfile.lint` to isolate non-execution/linting dependencies
- Update linting CI workflow to use `BUNDLE_GEMFILE=Gemfile.lint` for the yard-lint job
- Add `Gemfile.lint` to Renovate's `includePaths` for automatic dependency updates

## Test plan

- [ ] Verify yard-lint CI job uses the separate Gemfile
- [ ] Confirm Renovate detects and tracks `Gemfile.lint`