### PR TITLE
Add missing RD_KAFKA_RESOURCE_PATTERN_UNKNOWN constant

### DIFF
--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -370,6 +370,8 @@ module Rdkafka
     #   - RD_KAFKA_RESOURCE_BROKER  = 4
     # @param resource_name [String] name of the resource
     # @param resource_pattern_type [Integer] rd_kafka_ResourcePatternType_t value:
+    #   - RD_KAFKA_RESOURCE_PATTERN_UNKNOWN  = 0
+    #   - RD_KAFKA_RESOURCE_PATTERN_ANY      = 1
     #   - RD_KAFKA_RESOURCE_PATTERN_MATCH    = 2
     #   - RD_KAFKA_RESOURCE_PATTERN_LITERAL  = 3
     #   - RD_KAFKA_RESOURCE_PATTERN_PREFIXED = 4
@@ -469,6 +471,8 @@ module Rdkafka
     #   - RD_KAFKA_RESOURCE_BROKER  = 4
     # @param resource_name [String, nil] name of the resource or nil for any
     # @param resource_pattern_type [Integer] rd_kafka_ResourcePatternType_t value:
+    #   - RD_KAFKA_RESOURCE_PATTERN_UNKNOWN  = 0
+    #   - RD_KAFKA_RESOURCE_PATTERN_ANY      = 1
     #   - RD_KAFKA_RESOURCE_PATTERN_MATCH    = 2
     #   - RD_KAFKA_RESOURCE_PATTERN_LITERAL  = 3
     #   - RD_KAFKA_RESOURCE_PATTERN_PREFIXED = 4
@@ -570,6 +574,8 @@ module Rdkafka
     #   - RD_KAFKA_RESOURCE_BROKER  = 4
     # @param resource_name [String, nil] name of the resource or nil for any
     # @param resource_pattern_type [Integer] rd_kafka_ResourcePatternType_t value:
+    #   - RD_KAFKA_RESOURCE_PATTERN_UNKNOWN  = 0
+    #   - RD_KAFKA_RESOURCE_PATTERN_ANY      = 1
     #   - RD_KAFKA_RESOURCE_PATTERN_MATCH    = 2
     #   - RD_KAFKA_RESOURCE_PATTERN_LITERAL  = 3
     #   - RD_KAFKA_RESOURCE_PATTERN_PREFIXED = 4

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -561,6 +561,7 @@ module Rdkafka
     RD_KAFKA_RESOURCE_TRANSACTIONAL_ID = 5
 
     # rd_kafka_ResourcePatternType_t - https://github.com/confluentinc/librdkafka/blob/292d2a66b9921b783f08147807992e603c7af059/src/rdkafka.h#L7320
+    RD_KAFKA_RESOURCE_PATTERN_UNKNOWN = 0
     RD_KAFKA_RESOURCE_PATTERN_ANY = 1
     RD_KAFKA_RESOURCE_PATTERN_MATCH = 2
     RD_KAFKA_RESOURCE_PATTERN_LITERAL = 3


### PR DESCRIPTION
## Summary
- Added the missing `RD_KAFKA_RESOURCE_PATTERN_UNKNOWN` constant (value 0) to the ResourcePatternType constants in bindings
- This constant exists in librdkafka but was not previously mapped in the Ruby bindings

Fixes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)