### PR TITLE
Add poll_drain_nb method for time-bounded event draining

### DIFF
--- a/lib/rdkafka/helpers/time.rb
+++ b/lib/rdkafka/helpers/time.rb
@@ -9,6 +9,11 @@ module Rdkafka
       def monotonic_now
         ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       end
+
+      # @return [Integer] current monotonic time in milliseconds
+      def monotonic_now_ms
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :millisecond)
+      end
     end
   end
 end

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -258,26 +258,42 @@ module Rdkafka
 
     alias_method :queue_length, :queue_size
 
-    # Polls the producer for events without releasing the GVL (Global VM Lock).
+    # Drains the producer's event queue by continuously polling until empty or time limit reached.
     #
-    # This is more efficient than regular polling for non-blocking poll(0) calls,
-    # particularly useful in fiber scheduler contexts where GVL release/reacquire
-    # overhead is wasteful since we don't expect to wait.
+    # This method is useful when you need to ensure delivery callbacks are processed within a
+    # bounded time, particularly when polling multiple producers from a single thread where
+    # fair scheduling is required to prevent starvation.
     #
-    # @param timeout_ms [Integer] timeout in milliseconds (default: 0 for non-blocking)
-    # @return [Integer] the number of events served
+    # Uses non-blocking polls internally (no GVL release) for efficiency. The method holds
+    # a single `with_inner` lock for the duration, minimizing per-poll overhead when processing
+    # many events.
+    #
+    # @param timeout_ms [Integer] maximum time to spend draining in milliseconds (default: 100)
+    # @return [Boolean] true if no more events to process, false if stopped due to time limit
     # @raise [Rdkafka::ClosedProducerError] if called on a closed producer
     #
-    # @note This method is thread-safe as it uses the @native_kafka.with_inner synchronization
+    # @note This method holds the inner lock for up to `timeout_ms`. Other producer operations
+    #   (produce, close, etc.) will wait until this method returns.
+    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
     #
-    # @example
-    #   # In a fiber scheduler loop
-    #   producer.poll_nb  # Process any pending delivery callbacks without blocking
-    def poll_nb(timeout_ms = 0)
+    # @example Basic usage - drain for up to 100ms
+    #   fully_drained = producer.poll_drain_nb
+    #
+    # @example Round-robin polling multiple producers fairly
+    #   producers.each do |producer|
+    #     fully_drained = producer.poll_drain_nb(10)
+    #     # If false, this producer has more pending events
+    #   end
+    def poll_drain_nb(timeout_ms = 100)
       closed_producer_check(__method__)
 
       @native_kafka.with_inner do |inner|
-        Rdkafka::Bindings.rd_kafka_poll_nb(inner, timeout_ms)
+        deadline = monotonic_now_ms + timeout_ms
+
+        loop do
+          break true if Rdkafka::Bindings.rd_kafka_poll_nb(inner, 0).zero?
+          break false if monotonic_now_ms >= deadline
+        end
       end
     end
 

--- a/lib/rdkafka/producer/partitions_count_cache.rb
+++ b/lib/rdkafka/producer/partitions_count_cache.rb
@@ -147,17 +147,17 @@ module Rdkafka
 
           if current_info.nil?
             # Create new entry
-            @counts[topic] = [monotonic_now, new_count]
+            @counts[topic] = [monotonic_now_ms, new_count]
           else
             current_count = current_info[1]
 
             if new_count > current_count
               # Update to higher count value
-              current_info[0] = monotonic_now
+              current_info[0] = monotonic_now_ms
               current_info[1] = new_count
             else
               # Same or lower count, update timestamp only
-              current_info[0] = monotonic_now
+              current_info[0] = monotonic_now_ms
             end
           end
         end
@@ -211,15 +211,15 @@ module Rdkafka
         return unless current_info
 
         # Update the timestamp in-place
-        current_info[0] = monotonic_now
+        current_info[0] = monotonic_now_ms
       end
 
       # Check if a timestamp has expired based on the TTL
       #
-      # @param timestamp [Float] Monotonic timestamp to check
+      # @param timestamp [Integer] Monotonic timestamp in milliseconds to check
       # @return [Boolean] true if expired, false otherwise
       def expired?(timestamp)
-        (monotonic_now - timestamp) * 1_000 > @ttl_ms
+        monotonic_now_ms - timestamp > @ttl_ms
       end
     end
   end


### PR DESCRIPTION
## Summary

- Adds `poll_drain_nb(timeout_ms = 100)` method to `Rdkafka::Producer` that continuously polls events until the queue is empty or a time limit is reached
- Returns `true` if no more events to process, `false` if stopped due to time limit
- Uses non-blocking polls internally (no GVL release) for efficiency
- Holds a single `with_inner` lock for the duration, minimizing per-poll overhead when processing many events
- Removes `poll_nb` method from Producer as `poll_drain_nb` supersedes it
- Adds `monotonic_now_ms` helper to `Helpers::Time` for millisecond-precision monotonic time
- Updates `PartitionsCountCache` to use `monotonic_now_ms` for cleaner code (removes multiplication)

## Use Case

This method is useful when polling multiple producers from a single thread where fair scheduling is required to prevent starvation. By giving each producer a time quanta (e.g., 10ms), you can ensure no single producer monopolizes the polling thread:

```ruby
producers.each do |producer|
  fully_drained = producer.poll_drain_nb(10)
  # If false, this producer has more pending events
end
```

## Test plan

- [x] Added tests for boolean return type
- [x] Added tests for empty queue behavior (returns true)
- [x] Added tests for timeout behavior (returns false when time limit hit)
- [x] Added tests for custom timeout parameter
- [x] Added tests for delivery callback processing
- [x] Added tests for closed producer error handling
- [x] Updated closed producer method test matrix
- [x] Removed poll_nb tests