### PR TITLE
Add .ruby-version to renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "minimumReleaseAge": "7 days",
   "includePaths": [
+    ".ruby-version",
     "Gemfile",
     "Gemfile.lint",
     "package.json",


### PR DESCRIPTION
## Summary
- Add `.ruby-version` to Renovate's `includePaths` configuration

This enables Renovate to track and propose updates for the Ruby version specified in `.ruby-version`.

## Test plan
- Verify renovate.json is valid JSON
- Renovate will pick up the change on next scheduled run