### PR TITLE
Add docker-compose files to Renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
     "Gemfile",
     "Gemfile.lint",
     "package.json",
-    ".github/workflows/**"
+    ".github/workflows/**",
+    "docker-compose*.yml"
   ],
   "github-actions": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Adds `docker-compose*.yml` pattern to Renovate's `includePaths` configuration
- Enables automatic dependency updates for Docker images defined in compose files
- Docker Compose files (docker-compose.yml, docker-compose-ssl.yml) were previously excluded from Renovate scanning due to the allowlist nature of `includePaths`