### PR TITLE
Increase delete_group test timeout to fix CI flakiness

### DIFF
--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe Rdkafka::Admin do
             delete_group_handle = admin.delete_group(group_name)
 
             expect {
-              delete_group_handle.wait(max_wait_timeout_ms: 15_000)
+              delete_group_handle.wait(max_wait_timeout_ms: 30_000)
             }.to raise_exception { |ex|
               expect(ex).to be_a(Rdkafka::RdkafkaError)
               expect(ex.message).to match(/group_id_not_found|not_coordinator/)


### PR DESCRIPTION
The delete_group non-existent group test was timing out on slow CI environments at 15s, causing a WaitTimeoutError instead of the expected RdkafkaError. Bumped to 30s.