### PR TITLE
Optimize Headers.from_native: pre-allocate scratch pointers, dedup names

### DIFF
--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -51,7 +51,11 @@ module Rdkafka
           end
 
           name_ptr = name_ptrptr.read_pointer
-          name = name_ptr.respond_to?(:read_string_to_null) ? name_ptr.read_string_to_null : name_ptr.read_string
+          name = if name_ptr.respond_to?(:read_string_to_null)
+            -name_ptr.read_string_to_null
+          else
+            -name_ptr.read_string
+          end
 
           size = size_ptr[:value]
 


### PR DESCRIPTION
- Use String#-@ to deduplicate and freeze header name strings, reducing GC pressure for repeated header keys across messages.