### PR TITLE
Bump librdkafka to 2.14.1 and version to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.28.0 (Unreleased)
+- [Enhancement] Bump librdkafka to `2.14.1`
+
 ## 0.27.0 (2026-05-07)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue`.
 - [Feature] Add `Config#describe_properties` to dump all librdkafka configuration properties (including defaults and hidden properties) as a Hash via `rd_kafka_conf_dump`.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ bundle exec rake produce_messages
 
 | rdkafka-ruby | librdkafka | patches |
 |-|-|-|
+| 0.28.x (Unreleased) | 2.14.1 (2026-04-15) | yes |
 | 0.27.x (2026-05-07) | 2.14.0 (2026-04-01) | yes |
 | 0.26.x (2026-03-30) | 2.13.2 (2026-03-02) | yes |
 | 0.25.x (2026-01-21) | 2.12.1 (2025-10-21) | yes |

--- a/ext/build_common.sh
+++ b/ext/build_common.sh
@@ -19,7 +19,7 @@ readonly CYRUS_SASL_VERSION="2.1.28"
 readonly ZLIB_VERSION="1.3.1"
 readonly ZSTD_VERSION="1.5.7"
 readonly KRB5_VERSION="1.21.3"
-readonly LIBRDKAFKA_VERSION="2.14.0"
+readonly LIBRDKAFKA_VERSION="2.14.1"
 
 # SHA256 checksums for supply chain security
 # Update these when upgrading versions
@@ -29,7 +29,7 @@ declare -A CHECKSUMS=(
     ["zlib-1.3.1.tar.gz"]="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     ["zstd-${ZSTD_VERSION}.tar.gz"]="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"
     ["krb5-${KRB5_VERSION}.tar.gz"]="b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
-    ["librdkafka-${LIBRDKAFKA_VERSION}.tar.gz"]="c05c03ef00a13a8463fac3e8918c04843c416f11ced58c889d806a88ca92cf99"
+    ["librdkafka-${LIBRDKAFKA_VERSION}.tar.gz"]="bb246e754dee3560e9b42bf4e844dc05de4b146a3cae937e36301ffacdc456e7"
 )
 
 # Colors for output

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -2,9 +2,9 @@
 
 module Rdkafka
   # Current rdkafka-ruby gem version
-  VERSION = "0.27.0"
+  VERSION = "0.28.0"
   # Target librdkafka version to be used
-  LIBRDKAFKA_VERSION = "2.14.0"
+  LIBRDKAFKA_VERSION = "2.14.1"
   # SHA256 hash of the librdkafka source tarball for verification
-  LIBRDKAFKA_SOURCE_SHA256 = "c05c03ef00a13a8463fac3e8918c04843c416f11ced58c889d806a88ca92cf99"
+  LIBRDKAFKA_SOURCE_SHA256 = "bb246e754dee3560e9b42bf4e844dc05de4b146a3cae937e36301ffacdc456e7"
 end


### PR DESCRIPTION
- Update librdkafka from 2.14.0 to 2.14.1
- Update rdkafka-ruby version from 0.27.0 to 0.28.0
- Update SHA256 checksum for new tarball
- Update CHANGELOG and README version table

Closes #847