### PR TITLE
Fix poll_batch/poll_batch_nb silently discarding events after first e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.28.0 (Unreleased)
 - [Enhancement] Bump librdkafka to `2.14.1`
+- [Feature] `poll_batch` and `poll_batch_nb` now accept an optional block for error handling.
 
 ## 0.27.0 (2026-05-07)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0 (Unreleased)
 - [Enhancement] Bump librdkafka to `2.14.1`
-- [Fix] `poll_batch` and `poll_batch_nb` now accept an optional block to observe all error events in a batch before the first error is raised, preventing silent discard of subsequent error events.
+- [Breaking] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 
 ## 0.27.0 (2026-05-07)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0 (Unreleased)
 - [Enhancement] Bump librdkafka to `2.14.1`
-- [Feature] `poll_batch` and `poll_batch_nb` now accept an optional block for error handling.
+- [Fix] `poll_batch` and `poll_batch_nb` now accept an optional block to observe all error events in a batch before the first error is raised, preventing silent discard of subsequent error events.
 
 ## 0.27.0 (2026-05-07)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0 (Unreleased)
 - [Enhancement] Bump librdkafka to `2.14.1`
-- [Breaking] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
+- [Enhancement] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 
 ## 0.27.0 (2026-05-07)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue`.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -795,18 +795,21 @@ module Rdkafka
     # is available, librdkafka fills the buffer with whatever is immediately ready and
     # returns without further waiting.
     #
+    # Error events (e.g. `:partition_eof`) are returned inline as {RdkafkaError} objects
+    # rather than raised, so callers receive the complete batch — both messages and errors —
+    # and can decide how to handle each. This is particularly useful when multiple partitions
+    # signal EOF simultaneously: all signals appear in the returned array rather than only
+    # the first one being raised and the rest silently discarded.
+    #
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
-    # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
-    # @return [Array<Message>] Array of messages; empty when any error was encountered (errors
-    #   are raised, not returned — even in block mode where all errors are yielded first)
-    # @raise [RdkafkaError] When a consumed message contains an error
+    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch(timeout_ms, max_items: 100)
       closed_consumer_check(__method__)
 
       buffer = batch_buffer(max_items)
-      messages = []
+      results = []
 
       count = @native_kafka.with_inner do |_inner|
         Rdkafka::Bindings.rd_kafka_consume_batch_queue(
@@ -817,10 +820,9 @@ module Rdkafka
         )
       end
 
-      return messages if count <= 0
+      return results if count <= 0
 
       i = 0
-      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -833,20 +835,13 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            error = Rdkafka::RdkafkaError.new(native_message[:err])
+            results << Rdkafka::RdkafkaError.new(native_message[:err])
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
-
-            if block_given?
-              yield error
-              first_error ||= error
-              next
-            end
-
-            raise error
+            next
           end
 
-          messages << Rdkafka::Consumer::Message.new(native_message)
+          results << Rdkafka::Consumer::Message.new(native_message)
           Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
           i += 1
         end
@@ -858,8 +853,7 @@ module Rdkafka
         end
       end
 
-      raise first_error if first_error
-      messages
+      results
     end
 
     # Poll for a batch of messages without releasing the GVL (Global VM Lock).
@@ -871,18 +865,17 @@ module Rdkafka
     # @note Since the GVL is not released, a non-zero timeout_ms will block all Ruby
     #   threads/fibers for the duration. Use {#poll_batch} if you need a blocking wait.
     #
+    # Error events are returned inline as {RdkafkaError} objects; see {#poll_batch} for details.
+    #
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
-    # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
-    # @return [Array<Message>] Array of messages; empty when any error was encountered (errors
-    #   are raised, not returned — even in block mode where all errors are yielded first)
-    # @raise [RdkafkaError] When a consumed message contains an error
+    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch_nb(timeout_ms = 0, max_items: 100)
       closed_consumer_check(__method__)
 
       buffer = batch_buffer(max_items)
-      messages = []
+      results = []
 
       count = @native_kafka.with_inner do |_inner|
         Rdkafka::Bindings.rd_kafka_consume_batch_queue_nb(
@@ -893,10 +886,9 @@ module Rdkafka
         )
       end
 
-      return messages if count <= 0
+      return results if count <= 0
 
       i = 0
-      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -909,20 +901,13 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            error = Rdkafka::RdkafkaError.new(native_message[:err])
+            results << Rdkafka::RdkafkaError.new(native_message[:err])
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
-
-            if block_given?
-              yield error
-              first_error ||= error
-              next
-            end
-
-            raise error
+            next
           end
 
-          messages << Rdkafka::Consumer::Message.new(native_message)
+          results << Rdkafka::Consumer::Message.new(native_message)
           Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
           i += 1
         end
@@ -934,8 +919,7 @@ module Rdkafka
         end
       end
 
-      raise first_error if first_error
-      messages
+      results
     end
 
     # Poll for new messages and yield for each received one. Iteration

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -797,6 +797,7 @@ module Rdkafka
     #
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
+    # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
     # @return [Array<Message>] Array of messages (empty if none available within timeout)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
@@ -818,6 +819,7 @@ module Rdkafka
       return messages if count <= 0
 
       i = 0
+      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -830,7 +832,17 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            raise Rdkafka::RdkafkaError.new(native_message[:err])
+            error = Rdkafka::RdkafkaError.new(native_message[:err])
+            Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
+            i += 1
+
+            if block_given?
+              yield error
+              first_error ||= error
+              next
+            end
+
+            raise error
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)
@@ -845,6 +857,7 @@ module Rdkafka
         end
       end
 
+      raise first_error if first_error
       messages
     end
 
@@ -859,6 +872,7 @@ module Rdkafka
     #
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
+    # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
     # @return [Array<Message>] Array of messages (empty if none available within timeout)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
@@ -880,6 +894,7 @@ module Rdkafka
       return messages if count <= 0
 
       i = 0
+      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -892,7 +907,17 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            raise Rdkafka::RdkafkaError.new(native_message[:err])
+            error = Rdkafka::RdkafkaError.new(native_message[:err])
+            Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
+            i += 1
+
+            if block_given?
+              yield error
+              first_error ||= error
+              next
+            end
+
+            raise error
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)
@@ -907,6 +932,7 @@ module Rdkafka
         end
       end
 
+      raise first_error if first_error
       messages
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -798,7 +798,8 @@ module Rdkafka
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
     # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
-    # @return [Array<Message>] Array of messages (empty if none available within timeout)
+    # @return [Array<Message>] Array of messages; empty when any error was encountered (errors
+    #   are raised, not returned — even in block mode where all errors are yielded first)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch(timeout_ms, max_items: 100)
@@ -873,7 +874,8 @@ module Rdkafka
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
     # @yieldparam error [RdkafkaError] Each error event found in the batch (when block given)
-    # @return [Array<Message>] Array of messages (empty if none available within timeout)
+    # @return [Array<Message>] Array of messages; empty when any error was encountered (errors
+    #   are raised, not returned — even in block mode where all errors are yielded first)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch_nb(timeout_ms = 0, max_items: 100)

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1648,10 +1648,8 @@ RSpec.describe Rdkafka::Consumer do
       expect(batch.size).to be <= 3
     end
 
-    it "raises an error when a message has an error" do
-      message = Rdkafka::Bindings::Message.new.tap do |msg|
-        msg[:err] = 20
-      end
+    it "returns error events inline rather than raising" do
+      message = Rdkafka::Bindings::Message.new.tap { |msg| msg[:err] = 20 }
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
       buffer.put_pointer(0, message_pointer)
@@ -1662,12 +1660,13 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      expect {
-        consumer.poll_batch(100, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      results = consumer.poll_batch(100, max_items: 1)
+      expect(results.size).to eq(1)
+      expect(results.first).to be_a(Rdkafka::RdkafkaError)
+      expect(results.first.rdkafka_response).to eq(20)
     end
 
-    it "yields all errors to the block, continues processing, then raises the first" do
+    it "returns multiple error events from a batch in order" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
@@ -1683,20 +1682,13 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      yielded = []
-      raised = nil
-      begin
-        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
-      rescue Rdkafka::RdkafkaError => e
-        raised = e
-      end
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
-      expect(raised).to be_a(Rdkafka::RdkafkaError)
-      expect(raised.rdkafka_response).to eq(20)
+      results = consumer.poll_batch(100, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results).to all(be_a(Rdkafka::RdkafkaError))
+      expect(results.map(&:rdkafka_response)).to eq([20, 10])
     end
 
-    it "raises the error and does not return normal messages from a mixed batch" do
+    it "returns messages and errors interleaved in arrival order" do
       err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
       ptr_err = err_msg.to_ptr
@@ -1705,20 +1697,19 @@ RSpec.describe Rdkafka::Consumer do
       buffer.put_pointer(0, ptr_err)
       buffer.put_pointer(FFI::Pointer.size, ptr_ok)
 
+      fake_message = double("message")
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
-      # Stub Message.new so we don't call into librdkafka with a fake native struct
-      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(fake_message)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
       consumer.subscribe(topic)
 
-      yielded = []
-      expect {
-        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(1)
+      results = consumer.poll_batch(100, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results[0]).to be_a(Rdkafka::RdkafkaError)
+      expect(results[1]).to eq(fake_message)
     end
 
     context "when consumer is closed" do
@@ -1778,10 +1769,8 @@ RSpec.describe Rdkafka::Consumer do
       end
     end
 
-    it "raises an error when a message has an error" do
-      message = Rdkafka::Bindings::Message.new.tap do |msg|
-        msg[:err] = 20
-      end
+    it "returns error events inline rather than raising" do
+      message = Rdkafka::Bindings::Message.new.tap { |msg| msg[:err] = 20 }
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
       buffer.put_pointer(0, message_pointer)
@@ -1792,12 +1781,13 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      expect {
-        consumer.poll_batch_nb(0, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      results = consumer.poll_batch_nb(0, max_items: 1)
+      expect(results.size).to eq(1)
+      expect(results.first).to be_a(Rdkafka::RdkafkaError)
+      expect(results.first.rdkafka_response).to eq(20)
     end
 
-    it "yields all errors to the block, continues processing, then raises the first" do
+    it "returns multiple error events from a batch in order" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
@@ -1813,20 +1803,13 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      yielded = []
-      raised = nil
-      begin
-        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
-      rescue Rdkafka::RdkafkaError => e
-        raised = e
-      end
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
-      expect(raised).to be_a(Rdkafka::RdkafkaError)
-      expect(raised.rdkafka_response).to eq(20)
+      results = consumer.poll_batch_nb(0, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results).to all(be_a(Rdkafka::RdkafkaError))
+      expect(results.map(&:rdkafka_response)).to eq([20, 10])
     end
 
-    it "raises the error and does not return normal messages from a mixed batch" do
+    it "returns messages and errors interleaved in arrival order" do
       err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
       ptr_err = err_msg.to_ptr
@@ -1835,20 +1818,19 @@ RSpec.describe Rdkafka::Consumer do
       buffer.put_pointer(0, ptr_err)
       buffer.put_pointer(FFI::Pointer.size, ptr_ok)
 
+      fake_message = double("message")
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
-      # Stub Message.new so we don't call into librdkafka with a fake native struct
-      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(fake_message)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
       consumer.subscribe(topic)
 
-      yielded = []
-      expect {
-        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(1)
+      results = consumer.poll_batch_nb(0, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results[0]).to be_a(Rdkafka::RdkafkaError)
+      expect(results[1]).to eq(fake_message)
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -762,16 +762,26 @@ RSpec.describe Rdkafka::Consumer do
         ).wait
       end
 
-      # Consume to the end
+      # Consume to the end. We wait for assignment before polling so that
+      # partition positions are established — on slow CI (e.g. macOS) the EOF
+      # signal can fire before the first fetch completes if we start polling
+      # immediately, leaving no stored offsets and causing commit to fail.
+      # We also require at least one message to be consumed before stopping,
+      # for the same reason.
       consumer.subscribe(topic)
+      wait_for_assignment(consumer)
       eof_count = 0
+      messages_received = 0
+      deadline = Time.now + 30
       loop do
-        consumer.poll(100)
+        break if Time.now > deadline
+        msg = consumer.poll(100)
+        messages_received += 1 if msg
       rescue Rdkafka::RdkafkaError => error
         if error.is_partition_eof?
           eof_count += 1
         end
-        break if eof_count == 3
+        break if eof_count >= 3 && messages_received.positive?
       end
 
       # Commit

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1707,6 +1707,8 @@ RSpec.describe Rdkafka::Consumer do
 
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      # Stub Message.new so we don't call into librdkafka with a fake native struct
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
@@ -1835,6 +1837,8 @@ RSpec.describe Rdkafka::Consumer do
 
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      # Stub Message.new so we don't call into librdkafka with a fake native struct
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1669,7 +1669,7 @@ RSpec.describe Rdkafka::Consumer do
 
     it "yields all errors to the block, continues processing, then raises the first" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
-      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
       ptr2 = msg2.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 2)
@@ -1684,11 +1684,39 @@ RSpec.describe Rdkafka::Consumer do
       consumer.subscribe(topic)
 
       yielded = []
+      raised = nil
+      begin
+        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
+      rescue Rdkafka::RdkafkaError => e
+        raised = e
+      end
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(raised).to be_a(Rdkafka::RdkafkaError)
+      expect(raised.rdkafka_response).to eq(20)
+    end
+
+    it "raises the error and does not return normal messages from a mixed batch" do
+      err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
+      ptr_err = err_msg.to_ptr
+      ptr_ok = ok_msg.to_ptr
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr_err)
+      buffer.put_pointer(FFI::Pointer.size, ptr_ok)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
+
+      consumer.subscribe(topic)
+
+      yielded = []
       expect {
         consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
       }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(yielded.size).to eq(1)
     end
 
     context "when consumer is closed" do
@@ -1769,7 +1797,7 @@ RSpec.describe Rdkafka::Consumer do
 
     it "yields all errors to the block, continues processing, then raises the first" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
-      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
       ptr2 = msg2.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 2)
@@ -1784,11 +1812,39 @@ RSpec.describe Rdkafka::Consumer do
       consumer.subscribe(topic)
 
       yielded = []
+      raised = nil
+      begin
+        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
+      rescue Rdkafka::RdkafkaError => e
+        raised = e
+      end
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(raised).to be_a(Rdkafka::RdkafkaError)
+      expect(raised.rdkafka_response).to eq(20)
+    end
+
+    it "raises the error and does not return normal messages from a mixed batch" do
+      err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
+      ptr_err = err_msg.to_ptr
+      ptr_ok = ok_msg.to_ptr
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr_err)
+      buffer.put_pointer(FFI::Pointer.size, ptr_ok)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
+
+      consumer.subscribe(topic)
+
+      yielded = []
       expect {
         consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
       }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(yielded.size).to eq(1)
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1667,6 +1667,30 @@ RSpec.describe Rdkafka::Consumer do
       }.to raise_error(Rdkafka::RdkafkaError)
     end
 
+    it "yields all errors to the block, continues processing, then raises the first" do
+      msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ptr1 = msg1.to_ptr
+      ptr2 = msg2.to_ptr
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr1)
+      buffer.put_pointer(FFI::Pointer.size, ptr2)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr1)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr2)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+    end
+
     context "when consumer is closed" do
       before { consumer.close }
 
@@ -1741,6 +1765,30 @@ RSpec.describe Rdkafka::Consumer do
       expect {
         consumer.poll_batch_nb(0, max_items: 1)
       }.to raise_error(Rdkafka::RdkafkaError)
+    end
+
+    it "yields all errors to the block, continues processing, then raises the first" do
+      msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ptr1 = msg1.to_ptr
+      ptr2 = msg2.to_ptr
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr1)
+      buffer.put_pointer(FFI::Pointer.size, ptr2)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr1)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr2)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
     end
 
     context "when consumer is closed" do


### PR DESCRIPTION
…rror

Previously, when an error appeared in a batch returned by rd_kafka_consume_batch_queue, the code raised immediately inside the begin block. Control jumped to the ensure clause which destroyed all remaining native message pointers — including any subsequent error events from other partitions. Those events were permanently lost.

Both methods now accept an optional block. When a block is given:
- Each error is built before the pointer is destroyed.
- The error is yielded to the block and processing continues for remaining items.
- The first error is stored and raised after the full batch is processed.

Without a block the behaviour is unchanged.