### PR TITLE
Enable opt-in Ruby warning categories dynamically in spec helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.28.0 (Unreleased)
 - [Enhancement] Bump librdkafka to `2.14.1`
+- [Enhancement] Replace version-gated `Warning[:performance]` with dynamic `Warning.categories` opt-in in spec helper so new Ruby warning categories are automatically enabled without manual updates.
 - [Enhancement] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 
 ## 0.27.0 (2026-05-07)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-(Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true } if Warning.respond_to?(:categories)
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[experimental]).each do |cat|
+    Warning[cat] = true
+  end
+end
 $VERBOSE = true
 
 require "warning"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-if Warning.respond_to?(:categories)
-  Warning.categories.each { |cat| Warning[cat] = true }
-else
-  Warning[:deprecated] = true
-end
+Warning.categories.each { |cat| Warning[cat] = true } if Warning.respond_to?(:categories)
 $VERBOSE = true
 
 require "warning"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= "3.3"
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
 Warning[:deprecated] = true
 $VERBOSE = true
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
+require "warning"
+
 if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
 end
 $VERBOSE = true
-
-require "warning"
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+  Warning.categories.each { |cat| Warning[cat] = true }
+else
+  Warning[:deprecated] = true
 end
-Warning[:deprecated] = true
 $VERBOSE = true
 
 require "warning"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Warning.categories.each { |cat| Warning[cat] = true } if Warning.respond_to?(:categories)
+(Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true } if Warning.respond_to?(:categories)
 $VERBOSE = true
 
 require "warning"


### PR DESCRIPTION
Replace the version-gated `Warning[:performance] = true if RUBY_VERSION >= "3.3"` with a forward-compatible approach that enables all opt-in warning categories via `Warning.categories`. This mirrors the same improvement made in karafka-web (#1070) and ensures new warning categories added in future Ruby versions (e.g. `:strict_unused_block` in 3.4+) are automatically surfaced as test failures without requiring manual updates to the spec helper.