### PR TITLE
Align wrapped comment lines to the line length limit

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -490,8 +490,7 @@ module Rdkafka
       out = {}
 
       topic_partition_list.to_h.each do |topic, partitions|
-        # Query high watermarks for this topic's partitions
-        # and compare to the offset in the list.
+        # Query high watermarks for this topic's partitions and compare to the offset in the list.
         topic_out = {}
         partitions.each do |p|
           next if p.offset.nil?
@@ -572,8 +571,7 @@ module Rdkafka
     end
 
     # Seek to a particular message by providing the topic, partition and offset.
-    # The next poll on the topic/partition will return the
-    # message at the given offset.
+    # The next poll on the topic/partition will return the message at the given offset.
     #
     # @param topic [String] The topic in which to seek
     # @param partition [Integer] The partition number to seek
@@ -641,8 +639,7 @@ module Rdkafka
 
     # Manually commit the current offsets of this consumer.
     #
-    # To use this set `enable.auto.commit`to `false` to disable automatic triggering
-    # of commits.
+    # To use this set `enable.auto.commit`to `false` to disable automatic triggering of commits.
     #
     # If `enable.auto.offset.store` is set to `true` the offset of the last consumed
     # message for every partition is used. If set to `false` you can use {store_offset} to

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -55,8 +55,7 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_poll(@inner, 0)
 
         if @run_polling_thread
-          # Start thread to poll client for delivery callbacks,
-          # not used in consumer.
+          # Start thread to poll client for delivery callbacks, not used in consumer.
           @polling_thread = Thread.new do
             loop do
               @poll_mutex.synchronize do
@@ -197,8 +196,7 @@ module Rdkafka
           # Indicate to polling thread that we're closing
           @polling_thread[:closing] = true
 
-          # Wait for the polling thread to finish up,
-          # this can be aborted in practice if this
+          # Wait for the polling thread to finish up, this can be aborted in practice if this
           # code runs from a finalizer.
           @polling_thread.join
         end

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -410,8 +410,7 @@ module Rdkafka
       # based on the key when present.
       partition ||= Rdkafka::Bindings::RD_KAFKA_PARTITION_UA
 
-      # If timestamp is nil use 0 and let Kafka set one. If an integer or time
-      # use it.
+      # If timestamp is nil use 0 and let Kafka set one. If an integer or time use it.
       raw_timestamp = if timestamp.nil?
         0
       elsif timestamp.is_a?(Integer)

--- a/spec/integrations/ssl_stress_spec.rb
+++ b/spec/integrations/ssl_stress_spec.rb
@@ -82,8 +82,7 @@ timeout = 30
 start = Time.now
 
 # Wait for the servers to be available
-# We want to make sure that they are available so we are sure that librdkafka actually hammers
-# them
+# We want to make sure that they are available so we are sure that librdkafka actually hammers them
 loop do
   all_up = PORTS.all? do |port|
     TCPSocket.new("127.0.0.1", port).close

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -766,8 +766,7 @@ RSpec.describe Rdkafka::Consumer do
       # partition positions are established — on slow CI (e.g. macOS) the EOF
       # signal can fire before the first fetch completes if we start polling
       # immediately, leaving no stored offsets and causing commit to fail.
-      # We also require at least one message to be consumed before stopping,
-      # for the same reason.
+      # We also require at least one message to be consumed before stopping, for the same reason.
       consumer.subscribe(topic)
       wait_for_assignment(consumer)
       eof_count = 0
@@ -1051,8 +1050,7 @@ RSpec.describe Rdkafka::Consumer do
       handles.each(&:wait)
 
       consumer.subscribe(topic)
-      # Check the first 10 messages. Then close the consumer, which
-      # should break the each loop.
+      # Check the first 10 messages. Then close the consumer, which should break the each loop.
       consumer.each_with_index do |message, i|
         expect(message).to be_a Rdkafka::Consumer::Message
         break if i == 9
@@ -1348,8 +1346,7 @@ RSpec.describe Rdkafka::Consumer do
         handles.each(&:wait)
 
         consumer.subscribe(topic)
-        # Check the first 10 messages. Then close the consumer, which
-        # should break the each loop.
+        # Check the first 10 messages. Then close the consumer, which should break the each loop.
         consumer.each_with_index do |message, i|
           expect(message).to be_a Rdkafka::Consumer::Message
           break if i == 9

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,8 +72,7 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    # Timeout specs after 1.5 minute. If they take longer
-    # they are probably stuck
+    # Timeout specs after 1.5 minute. If they take longer they are probably stuck
     Timeout.timeout(90) do
       example.run
     end


### PR DESCRIPTION
Join prose comment lines that were split mid-sentence with no reason to stay under the line length limit. Skips license headers, YARD tags, code examples, feature-list bullets, and conceptually separate sentences.