### PR TITLE
Reuse per-fiber scratch pointers in Headers.from_native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
 ## Unreleased
+- [Enhancement] Reuse per-thread scratch pointers in `Consumer::Headers.from_native` instead of allocating them for every consumed message. Previously each message paid one native pointer allocation just to check for headers and three more when headers were present; now the scratch pointers are allocated once per thread/fiber and reused, removing all per-message native scratch allocations from the consumer hot path.
 - [Enhancement] Remove the unused `DeliveryHandle` `:topic_name` struct field and the per-message allocation that populated it. The delivery callback copied the topic name into a native `FFI::MemoryPointer` on every delivered message, retained for the lifetime of the handle, yet nothing ever read it: the topic is already available via `DeliveryHandle#topic` (a Ruby attribute set during `produce`) and `DeliveryReport#topic_name`, both of which work exactly as before.
 
 ## 0.28.0 (2026-06-03)

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -7,6 +7,11 @@ module Rdkafka
       # Empty frozen hash used when there are no headers
       EMPTY_HEADERS = {}.freeze
 
+      # Key under which reusable scratch pointers are stored on the current thread/fiber
+      SCRATCH_KEY = :rdkafka_headers_scratch
+
+      private_constant :SCRATCH_KEY
+
       # Reads a librdkafka native message's headers and returns them as a Ruby Hash
       # where each key maps to either a String (single value) or Array<String> (multiple values)
       # to support duplicate headers per KIP-82
@@ -17,7 +22,20 @@ module Rdkafka
       # @return [Hash{String => String, Array<String>}] headers Hash for the native_message
       # @raise [Rdkafka::RdkafkaError] when fail to read headers
       def self.from_native(native_message)
-        headers_ptrptr = FFI::MemoryPointer.new(:pointer)
+        # Scratch output pointers for the header FFI calls, reused across messages. They are
+        # stored in fiber-local storage (`Thread.current[]` is fiber-local by design), so each
+        # thread and each fiber gets its own set and reuse is safe with fiber schedulers. They
+        # never escape this method and all data is read out of them before returning.
+        # Allocating them per message would cost several native allocations for every consumed
+        # message.
+        headers_ptrptr, name_ptrptr, value_ptrptr, size_ptr =
+          Thread.current[SCRATCH_KEY] ||= [
+            FFI::MemoryPointer.new(:pointer),
+            FFI::MemoryPointer.new(:pointer),
+            FFI::MemoryPointer.new(:pointer),
+            Rdkafka::Bindings::SizePtr.new
+          ].freeze
+
         err = Rdkafka::Bindings.rd_kafka_message_headers(native_message, headers_ptrptr)
 
         if err == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__NOENT
@@ -27,10 +45,6 @@ module Rdkafka
         end
 
         headers_ptr = headers_ptrptr.read_pointer
-
-        name_ptrptr = FFI::MemoryPointer.new(:pointer)
-        value_ptrptr = FFI::MemoryPointer.new(:pointer)
-        size_ptr = Rdkafka::Bindings::SizePtr.new
 
         headers = {}
 

--- a/spec/lib/rdkafka/consumer/headers_spec.rb
+++ b/spec/lib/rdkafka/consumer/headers_spec.rb
@@ -70,4 +70,48 @@ RSpec.describe Rdkafka::Consumer::Headers do
       expect(headers.key?(:version)).to be(false)
     end
   end
+
+  describe ".from_native scratch pointers reuse" do
+    let(:native_message) { double("native message") }
+
+    before do
+      allow(Rdkafka::Bindings)
+        .to receive(:rd_kafka_message_headers)
+        .and_return(Rdkafka::Bindings::RD_KAFKA_RESP_ERR__NOENT)
+    end
+
+    it "does not allocate native scratch pointers after the first call on a thread" do
+      # Warm up the per-thread scratch pointers
+      described_class.from_native(native_message)
+
+      expect(FFI::MemoryPointer).not_to receive(:new)
+      expect(Rdkafka::Bindings::SizePtr).not_to receive(:new)
+
+      expect(described_class.from_native(native_message)).to eq(described_class::EMPTY_HEADERS)
+    end
+
+    it "uses separate scratch pointers per thread" do
+      pointers = Array.new(2) do
+        Thread.new do
+          described_class.from_native(native_message)
+          Thread.current[:rdkafka_headers_scratch]
+        end.value
+      end
+
+      expect(pointers[0]).not_to be_nil
+      expect(pointers[0]).not_to eq(pointers[1])
+    end
+
+    it "uses separate scratch pointers per fiber within the same thread" do
+      pointers = Array.new(2) do
+        Fiber.new do
+          described_class.from_native(native_message)
+          Thread.current[:rdkafka_headers_scratch]
+        end.resume
+      end
+
+      expect(pointers[0]).not_to be_nil
+      expect(pointers[0]).not_to eq(pointers[1])
+    end
+  end
 end


### PR DESCRIPTION
Every consumed message allocated one native scratch pointer just to check for headers and three more (name, value, size) when headers were present. These are pure output parameters for the header FFI calls: they never escape the method and all data is read out of them before returning, so they can be allocated once per fiber and reused.

The scratch set lives in fiber-local storage (Thread.current[] is fiber-local by design), so each thread and each fiber gets its own pointers and reuse stays safe under fiber schedulers.

This removes all per-message native scratch allocations from the consumer hot path (one to four mallocs plus up to six Ruby objects per message, depending on header presence).