### PR TITLE
Bump librdkafka to 2.14.2 and version to 0.29.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Ignore bundler config.
 /.bundle
 
-Gemfile.lock
 ext/ports
 ext/tmp
 ext/librdkafka.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
-## Unreleased
+## 0.29.0 (Unreleased)
+- [Enhancement] Bump librdkafka to `2.14.2`
 - [Enhancement] Support offset-commit metadata: `Consumer#store_offset(message, metadata)` stores an optional metadata string alongside the offset, `Consumer::Partition#metadata` exposes it, and `TopicPartitionList` marshals it to and from the native list (read back via `Consumer#committed`).
 - [Fix] Cache the partition count for a missing topic. `Producer#partition_count` rescued `unknown_topic_or_part` outside the cache block, so nothing was cached and every `produce(partition_key:)` to a missing topic re-ran a blocking metadata query. The rescue now runs inside the cache block so `RD_KAFKA_PARTITION_UA` is cached like any other count; other errors are still re-raised.
 - [Fix] Let `PartitionsCountCache` adopt a lower partition count once the cached entry has expired. The cache prioritizes higher counts (partition counts only grow during normal operation), but it did so unconditionally: after the TTL expired it fetched the true lower count, discarded it, and re-armed the TTL on the stale higher count - permanently. A topic recreated with fewer partitions then made `produce` (with a partition key) fail with `unknown_partition` for the dropped partitions until process restart. A lower value is now adopted on the first refresh after expiry, while still being ignored within the TTL window so a transient or racy lower read cannot clobber a correct higher count.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,80 @@
+PATH
+  remote: .
+  specs:
+    rdkafka (0.29.0)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    json (2.13.2)
+    logger (1.7.0)
+    method_source (1.1.0)
+    mini_portile2 (2.8.9)
+    ostruct (0.6.3)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.3.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    warning (1.5.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  ostruct
+  pry
+  rdkafka!
+  rspec
+  simplecov
+  warning
+
+BUNDLED WITH
+   2.7.1

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ bundle exec rake produce_messages
 
 | rdkafka-ruby | librdkafka | patches |
 |-|-|-|
+| 0.29.x (Unreleased) | 2.14.2 (2026-06-03) | yes |
 | 0.28.x (2026-06-03) | 2.14.1 (2026-04-15) | yes |
 | 0.27.x (2026-05-07) | 2.14.0 (2026-04-01) | yes |
 | 0.26.x (2026-03-30) | 2.13.2 (2026-03-02) | yes |

--- a/ext/build_common.sh
+++ b/ext/build_common.sh
@@ -19,7 +19,7 @@ readonly CYRUS_SASL_VERSION="2.1.28"
 readonly ZLIB_VERSION="1.3.1"
 readonly ZSTD_VERSION="1.5.7"
 readonly KRB5_VERSION="1.21.3"
-readonly LIBRDKAFKA_VERSION="2.14.1"
+readonly LIBRDKAFKA_VERSION="2.14.2"
 
 # SHA256 checksums for supply chain security
 # Update these when upgrading versions
@@ -29,7 +29,7 @@ declare -A CHECKSUMS=(
     ["zlib-1.3.1.tar.gz"]="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     ["zstd-${ZSTD_VERSION}.tar.gz"]="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"
     ["krb5-${KRB5_VERSION}.tar.gz"]="b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
-    ["librdkafka-${LIBRDKAFKA_VERSION}.tar.gz"]="bb246e754dee3560e9b42bf4e844dc05de4b146a3cae937e36301ffacdc456e7"
+    ["librdkafka-${LIBRDKAFKA_VERSION}.tar.gz"]="d7eec9c31c817fa44402f679c252dfbf97e4c338a849a25c3579a31fd127beb8"
 )
 
 # Colors for output

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -2,9 +2,9 @@
 
 module Rdkafka
   # Current rdkafka-ruby gem version
-  VERSION = "0.28.0"
+  VERSION = "0.29.0"
   # Target librdkafka version to be used
-  LIBRDKAFKA_VERSION = "2.14.1"
+  LIBRDKAFKA_VERSION = "2.14.2"
   # SHA256 hash of the librdkafka source tarball for verification
-  LIBRDKAFKA_SOURCE_SHA256 = "bb246e754dee3560e9b42bf4e844dc05de4b146a3cae937e36301ffacdc456e7"
+  LIBRDKAFKA_SOURCE_SHA256 = "d7eec9c31c817fa44402f679c252dfbf97e4c338a849a25c3579a31fd127beb8"
 end


### PR DESCRIPTION
- Update librdkafka from 2.14.1 to 2.14.2
- Update rdkafka-ruby version from 0.28.0 to 0.29.0
- Update SHA256 checksum for new tarball
- Update CHANGELOG and README version table