### PR TITLE
Fix SimpleCov add_filter deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ GEM
   specs:
     coderay (1.1.3)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -47,12 +46,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
     warning (1.6.0)
 
 PLATFORMS

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ end
 unless ENV["CI"] == "true"
   require "simplecov"
   SimpleCov.start do
-    add_filter "/spec/"
+    skip "/spec/"
   end
 end
 


### PR DESCRIPTION
SimpleCov 1.0.0 renamed `add_filter` to `skip` and the old name now emits a deprecation warning. The spec helper promotes warnings to errors, so the suite would break as soon as SimpleCov resolved to 1.0.0.

- spec/spec_helper.rb: use `skip "/spec/"` instead of `add_filter "/spec/"`
- Gemfile.lock: bump simplecov 0.22.0 -> 1.0.0 (`skip` only exists in
  >= 1.0.0). simplecov 1.0.0 has no runtime dependencies, so docile,
  simplecov-html and simplecov_json_formatter drop out of the lockfile.