### PR TITLE
Clear the shared handle registry in producer_spec after-hook to stop …

### DIFF
--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -19,27 +19,9 @@ RSpec.describe Rdkafka::Admin do
   let(:permission_type) { Rdkafka::Bindings::RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW }
   let(:admin) { config.admin }
 
-  around do |example|
-    example.run
-  ensure
-    # Registry should always end up being empty after each test.
-    # We check and then clear to prevent cascading failures when a single test
-    # leaves a leaked handle (e.g. due to a timeout or broker error).
-    #
-    # The registry is one hash shared by every handle class (it lives on AbstractHandle and is
-    # inherited as the same object), so it is inspected once and the classes of the actual
-    # leaked handles are reported. The previous per-class checks all aliased the same hash, so a
-    # single leaked handle blamed every listed class - none of which had to be the leaking one.
-    leaked_handles = Rdkafka::AbstractHandle::REGISTRY.values
-
-    Rdkafka::AbstractHandle::REGISTRY.clear
-
-    admin.close
-
-    leaked_names = leaked_handles.map { |handle| handle.class.name }.uniq.sort
-
-    expect(leaked_handles).to be_empty, "Leaked handles in: #{leaked_names.join(", ")}"
-  end
+  # Close the memoized admin after each example so cleanup does not rely on the GC finalizer. The
+  # shared registry-empty check lives in the global hook in spec_helper.
+  after { admin.close }
 
   describe "#describe_errors" do
     let(:errors) { admin.class.describe_errors }

--- a/spec/lib/rdkafka/producer_spec.rb
+++ b/spec/lib/rdkafka/producer_spec.rb
@@ -10,16 +10,9 @@ RSpec.describe Rdkafka::Producer do
   let(:topic) { TestTopics.create }
   let(:topic_25) { TestTopics.create(partitions: 25) }
 
+  # Close the clients after each example. The shared registry-empty check lives in the global hook
+  # in spec_helper.
   after do
-    # Registry should always end up being empty.
-    # Async delivery callbacks may not have fired yet, so poll briefly.
-    registry = Rdkafka::Producer::DeliveryHandle::REGISTRY
-    10.times do
-      break if registry.empty?
-
-      sleep(0.05)
-    end
-    expect(registry).to be_empty, registry.inspect
     producer.close
     consumer.close
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,4 +78,31 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  # The handle registry (`AbstractHandle::REGISTRY`) is one process-global hash shared by every
+  # handle class. After each example it must be empty; a handle left behind - e.g. a
+  # `CreateTopicHandle` orphaned when topic setup times out against a slow broker - is otherwise
+  # visible to every later example, turning a single leak into a cascade of identical failures.
+  #
+  # We capture, CLEAR unconditionally, then assert - so the clear always runs (a raising assertion
+  # must never skip it) and a leak fails only the example that caused it. `append_after` runs this
+  # after each group's own `after` hooks, so the clients that own the handles have already been
+  # closed and only genuinely-orphaned handles remain.
+  config.append_after do
+    registry = Rdkafka::AbstractHandle::REGISTRY
+
+    # Async delivery/background callbacks may not have fired yet; give them a brief moment.
+    10.times do
+      break if registry.empty?
+
+      sleep(0.05)
+    end
+
+    leaked_handles = registry.values
+    registry.clear
+
+    leaked_names = leaked_handles.map { |handle| handle.class.name }.uniq.sort
+
+    expect(leaked_handles).to be_empty, "Leaked handles in: #{leaked_names.join(", ")}"
+  end
 end


### PR DESCRIPTION
…leak cascades

The producer after-hook asserted the process-global AbstractHandle::REGISTRY was empty but never cleared it - and the assertion raised before any clear could run. So a single orphaned handle (e.g. a CreateTopicHandle left pending when topic setup times out against a slow broker) reddened not just its own example but every later example that shares the registry: one leak turned into dozens of failures (74 in a recent scheduled aarch64 run).

Mirror the admin specs: capture the leaked handles, clear the registry, close the clients, then assert - so the clear always happens and a leak fails only the example that caused it. Also switch the check to the shared AbstractHandle::REGISTRY (same object the DeliveryHandle alias pointed at) so a leaked handle of any type is reported by class name rather than a raw inspect.