### PR TITLE
Wait for partition leaders before #list_offsets queries instead of ra…

### DIFF
--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -548,10 +548,13 @@ RSpec.describe Rdkafka::Admin do
       let(:topic) { TestTopics.create }
 
       before do
-        # Produce a message to ensure partition leaders are fully established
-        producer = rdkafka_config.producer
-        producer.produce(topic: topic, payload: "warmup", partition: 0).wait
-        producer.close
+        # Warm up every partition these examples query so their leaders are actually serving before
+        # we ask for offsets. A ListOffsets request for a partition whose leader has been elected in
+        # metadata but is not yet serving fails with not_leader_for_partition; the "multiple
+        # partitions at once" example queries partition 1, which the old partition-0-only warmup
+        # never established, so it raced leader election. Producing also gives these "with messages"
+        # examples real data.
+        warm_up_partitions(topic, 0, 1)
       end
 
       it "returns earliest offsets" do
@@ -606,21 +609,14 @@ RSpec.describe Rdkafka::Admin do
     context "when querying offsets by timestamp" do
       let(:topic) { TestTopics.create }
 
+      # Warm up partition 0 so its leader is serving before the query (see warm_up_partitions).
+      before { warm_up_partitions(topic, 0) }
+
       it "returns offsets for a given timestamp" do
         # Use a timestamp of 0 (epoch) to get earliest messages.
-        # Retry on transient broker errors (not_leader_for_partition) that can
-        # occur when partition leadership hasn't fully settled after topic creation.
-        report = nil
-        3.times do
-          report = admin.list_offsets(
-            { topic => [{ partition: 0, offset: 0 }] }
-          ).wait(max_wait_timeout_ms: 15_000)
-          break
-        rescue Rdkafka::RdkafkaError => e
-          raise unless e.message.include?("not_leader_for_partition")
-
-          sleep(1)
-        end
+        report = admin.list_offsets(
+          { topic => [{ partition: 0, offset: 0 }] }
+        ).wait(max_wait_timeout_ms: 15_000)
 
         expect(report.offsets.length).to eq(1)
         first = report.offsets.first

--- a/spec/support/kafka_wait_helpers.rb
+++ b/spec/support/kafka_wait_helpers.rb
@@ -87,6 +87,28 @@ module KafkaWaitHelpers
     retry
   end
 
+  # Produces (and waits for) a message to each given partition so their leaders are actually
+  # serving before the test queries them.
+  #
+  # Right after a topic is created, a partition can appear in metadata with an elected leader
+  # before that broker is ready to serve it, so a ListOffsets/fetch request still fails with
+  # +not_leader_for_partition+. A metadata check is therefore not enough. A successful produce is a
+  # full round-trip to the leader - librdkafka retries it internally until leadership settles - so
+  # once it completes the partition is genuinely ready to be queried.
+  #
+  # @param topic [String] the topic to produce to
+  # @param partitions [Array<Integer>] the partitions to warm up
+  # @return [void]
+  def warm_up_partitions(topic, *partitions)
+    producer = rdkafka_config.producer
+
+    partitions.each do |partition|
+      producer.produce(topic: topic, payload: "warmup", partition: partition).wait
+    end
+  ensure
+    producer&.close
+  end
+
   # Polls +describe_configs+ for a resource until the named config reports the
   # expected value, or the timeout elapses. Broker acknowledgment of an
   # +incremental_alter_configs+ request does not guarantee the change is


### PR DESCRIPTION
…cing them

The '#list_offsets returns offsets for multiple partitions at once' spec failed intermittently with 'Not leader for partition (not_leader_for_partition)'. Right after a topic is created, partition leadership has not yet propagated across the cluster, so a ListOffsets request for a partition whose leader is still being elected fails. The example queries partition 1, which the before-hook never established (it produced a warmup only to partition 0).

Add KafkaWaitHelpers#wait_for_partition_leaders, which polls topic metadata until every partition reports a valid leader (a non-negative broker id), tolerating the transient unknown_topic_or_part / leader_not_available errors metadata itself can raise while leadership settles. The list_offsets contexts call it before querying, so the queries run against settled leadership deterministically - no retry-on-error loop and no reliance on producing to every partition to force leader election.