### PR TITLE
Bump bundled OpenSSL to 3.5.8 (LTS) and fix its Renovate matcher

### DIFF
--- a/ext/build_common.sh
+++ b/ext/build_common.sh
@@ -14,7 +14,7 @@ fi
 BUILD_COMMON_SOURCED=1
 
 # Version constants - update these to upgrade dependencies
-readonly OPENSSL_VERSION="3.0.16"
+readonly OPENSSL_VERSION="3.5.8"
 readonly CYRUS_SASL_VERSION="2.1.28"
 readonly ZLIB_VERSION="1.3.1"
 readonly ZSTD_VERSION="1.5.7"
@@ -24,7 +24,7 @@ readonly LIBRDKAFKA_VERSION="2.14.2"
 # SHA256 checksums for supply chain security
 # Update these when upgrading versions
 declare -A CHECKSUMS=(
-    ["openssl-${OPENSSL_VERSION}.tar.gz"]="57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86"
+    ["openssl-${OPENSSL_VERSION}.tar.gz"]="a8f84a39918ec6415ce765d9b429d313ba97b8143169c172e734b9514464f5b2"
     ["cyrus-sasl-${CYRUS_SASL_VERSION}.tar.gz"]="7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c"
     ["zlib-1.3.1.tar.gz"]="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     ["zstd-${ZSTD_VERSION}.tar.gz"]="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       ],
       "depNameTemplate": "openssl/openssl",
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^OpenSSL_(?<version>.*)$"
+      "extractVersionTemplate": "^openssl-(?<version>.*)$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
The precompiled gems statically link **OpenSSL 3.0.16** (Feb 2025). Two problems:

- The OpenSSL **3.0 LTS branch reaches end-of-life on 2026-09-07**, and 3.0.x is already at 3.0.22 — so the bundled copy is six patch releases behind on a branch about to stop receiving fixes entirely.
- **librdkafka itself moved to OpenSSL 3.5.6 in 2.14.2** for CVE coverage, but `build_common.sh` overrides that with its own pin, so gem users never received it.

This moves the pin to **3.5.8**, the current 3.5 LTS release (EOL 2030-04-08).

### Why the pin has been stuck since Feb 2025

The Renovate custom manager for this pin extracts versions with:

```
"extractVersionTemplate": "^OpenSSL_(?<version>.*)$"
```

That only matches the legacy 1.1.1-era tags (`OpenSSL_1_1_1w`). Current releases are tagged `openssl-3.5.8`, so of the last 100 `openssl/openssl` releases the only matches are eleven 1.1.1 tags — nothing ever matched a 3.x release and no update was ever proposed. Fixing the template keeps this current going forward. The sibling managers for zlib/zstd/krb5/cyrus-sasl look fine.

### Validation

Built `ext/build_macos_arm64.sh` before and after on macOS arm64:

| | master (3.0.16) | this PR (3.5.8) |
|---|---|---|
| Build exit code | 1 | 1 — identical |
| zstd dylib link error | present | present — identical |
| `librdkafka.dylib` produced | yes | yes |
| Embedded banner | `OpenSSL 3.0.16` | `OpenSSL 3.5.8` |
| 3.5 PQ identifiers | absent | present (`X25519MLKEM768`, `MLKEM1024`, `ML-DSA-44`) |
| Dynamic `libssl`/`libcrypto` | none | none |

Note the exit code and zstd link error reproduce identically on unmodified `master`, so they're pre-existing on macOS and unrelated to this change — I baselined specifically to confirm.

### This also fixes a real interoperability bug

OpenSSL 3.0.16 doesn't resolve IANA-style cipher names. Recent Wolfi/Chainguard images ship a system `/etc/ssl/openssl.cnf` whose `CipherString` is written that way, and the statically linked OpenSSL inside the gem reads it — leaving the client with no usable TLS 1.2 cipher, so every handshake fails with `alert number 40` against a TLS 1.2-only broker. Ruby's own (newer) OpenSSL in the same process parses the file correctly, which makes it look like a Kafka-specific fault.

Tested through the gem's own FFI against the patched build:

```
3.0.16:  ssl.cipher.suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  ->  "no cipher match"
3.5.8:   same value                                              ->  accepted
3.5.8:   full IANA list with @SECLEVEL=2                          ->  accepted
```

### Question for maintainers

`dist/openssl-3.0.16.tar.gz` is committed. `secure_download` falls back to fetching from openssl.org with checksum verification, so this works as-is (that's the path my build exercised), but it leaves `dist/` out of sync. Happy to add `dist/openssl-3.5.8.tar.gz` and drop the old one if you'd like `dist/` kept authoritative — I didn't want to push a 15 MB binary unrequested.

Also happy to add a CHANGELOG entry; `master` sits at `v0.29.1` with no Unreleased section so I didn't want to guess at your release flow.

### Possible follow-up (not in this PR)

The deeper issue is that the bundled static OpenSSL reads the **system** config at all, because it's built with `--openssldir="/etc/ssl"`. Pointing it at a private directory would eliminate this whole class of failure rather than this instance. It also controls default CA trust, so it needs care — I'd rather open a separate issue to discuss than fold it into a version bump.

*Patch prepared with assistance from Claude; the commit carries a `Co-Authored-By` trailer.*
